### PR TITLE
add pyproject.toml for easier black usage, update flake8 to match

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,8 +1,6 @@
 # Flake8 config designed to work with black
 [flake8]
 ignore = E203, E266, E501, W503
-# line length is intentionally set to 80 here because black uses Bugbear
-# See https://github.com/psf/black/blob/master/README.md#line-length for more details
-max-line-length = 80
+max-line-length = 88
 max-complexity = 18
 select = B,C,E,F,W,T4,B9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ exclude = '''
   | \.mypy_cache
   | \.tox
   | \.?venv
-  | \.dir-env
+  | \.direnv
   | _build
   | buck-out
   | build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.black]
+line-length = 88
+target-version = ['py36', 'py37', 'py38']
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.?venv
+  | \.dir-env
+  | _build
+  | buck-out
+  | build
+  | dist
+)/
+'''


### PR DESCRIPTION
## Changes proposed in this pull request:

- Get ready to paint it black

## Security considerations

None