### PR TITLE
use UPSERT rather than create for Route53 changes

### DIFF
--- a/broker/tasks/route53.py
+++ b/broker/tasks/route53.py
@@ -28,7 +28,7 @@ def create_TXT_records(operation_id: int, **kwargs):
             ChangeBatch={
                 "Changes": [
                     {
-                        "Action": "CREATE",
+                        "Action": "UPSERT",
                         "ResourceRecordSet": {
                             "Type": "TXT",
                             "Name": txt_record,
@@ -128,7 +128,7 @@ def create_ALIAS_records(operation_id: str, **kwargs):
             ChangeBatch={
                 "Changes": [
                     {
-                        "Action": "CREATE",
+                        "Action": "UPSERT",
                         "ResourceRecordSet": {
                             "Type": "A",
                             "Name": alias_record,

--- a/tests/lib/fake_route53.py
+++ b/tests/lib/fake_route53.py
@@ -16,7 +16,7 @@ class FakeRoute53(FakeAWS):
                 "ChangeBatch": {
                     "Changes": [
                         {
-                            "Action": "CREATE",
+                            "Action": "UPSERT",
                             "ResourceRecordSet": {
                                 "Name": domain,
                                 "ResourceRecords": [{"Value": self.ANY}],
@@ -89,7 +89,7 @@ class FakeRoute53(FakeAWS):
                 "ChangeBatch": {
                     "Changes": [
                         {
-                            "Action": "CREATE",
+                            "Action": "UPSERT",
                             "ResourceRecordSet": {
                                 "Name": domain,
                                 "Type": "A",


### PR DESCRIPTION
fixes #119

## Changes proposed in this pull request:

-  use UPSERT to update route53 records

## Security considerations

None