### PR TITLE
freshen ETag in cloudfront delete step

### DIFF
--- a/broker/tasks/cloudfront.py
+++ b/broker/tasks/cloudfront.py
@@ -181,7 +181,7 @@ def wait_for_distribution_disabled(operation_id: int, **kwargs):
 
 
 @huey.retriable_task
-def delete_distribution(etag: str, operation_id: int, **kwargs):
+def delete_distribution(str, operation_id: int, **kwargs):
     operation = Operation.query.get(operation_id)
     service_instance = operation.service_instance
 
@@ -190,8 +190,11 @@ def delete_distribution(etag: str, operation_id: int, **kwargs):
     db.session.commit()
 
     try:
+        status = cloudfront.get_distribution(
+            Id=service_instance.cloudfront_distribution_id
+        )
         cloudfront.delete_distribution(
-            Id=service_instance.cloudfront_distribution_id, IfMatch=etag
+            Id=service_instance.cloudfront_distribution_id, IfMatch=status["ETag"]
         )
     except cloudfront.exceptions.NoSuchDistribution:
         return

--- a/tests/integration/cdn/test_cdn_deprovisioning.py
+++ b/tests/integration/cdn/test_cdn_deprovisioning.py
@@ -250,6 +250,16 @@ def subtest_deprovision_waits_for_cloudfront_distribution_disabled(
 def subtest_deprovision_removes_cloudfront_distribution(
     tasks, service_instance, cloudfront
 ):
+    cloudfront.expect_get_distribution(
+        caller_reference=service_instance.id,
+        domains=service_instance.domain_names,
+        certificate_id=service_instance.iam_server_certificate_id,
+        origin_hostname=service_instance.cloudfront_origin_hostname,
+        origin_path=service_instance.cloudfront_origin_path,
+        distribution_id=service_instance.cloudfront_distribution_id,
+        status="Deployed",
+        enabled=False,
+    )
     cloudfront.expect_delete_distribution(
         distribution_id=service_instance.cloudfront_distribution_id
     )
@@ -281,7 +291,7 @@ def subtest_deprovision_waits_for_cloudfront_distribution_disabled_when_missing(
 def subtest_deprovision_removes_cloudfront_distribution_when_missing(
     tasks, service_instance, cloudfront
 ):
-    cloudfront.expect_delete_distribution_returning_no_such_distribution(
+    cloudfront.expect_get_distribution_returning_no_such_distribution(
         distribution_id=service_instance.cloudfront_distribution_id
     )
     tasks.run_queued_tasks_and_enqueue_dependents()


### PR DESCRIPTION
## Changes proposed in this pull request:

- get the distribution again in the delete step so we have a fresh ETag

## Security considerations

None