### PR TITLE
don't update ALBs when nothing has changed

### DIFF
--- a/tests/integration/alb/test_alb_provisioning.py
+++ b/tests/integration/alb/test_alb_provisioning.py
@@ -10,7 +10,7 @@ from broker.tasks.alb import get_lowest_used_alb
 from tests.lib.factories import ALBServiceInstanceFactory
 from tests.lib.client import check_last_operation_description
 
-from tests.integration.alb.test_alb_update import subtest_update_happy_path
+from tests.integration.alb.test_alb_update import subtest_update_happy_path, subtest_update_noop
 
 # The subtests below are "interesting".  Before test_provision_happy_path, we
 # had separate tests for each stage in the task pipeline.  But each test would
@@ -208,7 +208,7 @@ def test_provision_happy_path(
     subtest_update_happy_path(
         client, dns, tasks, route53, iam_govcloud, simple_regex, alb
     )
-
+    subtest_update_noop(client)
 
 def subtest_provision_creates_provision_operation(client, dns):
     dns.add_cname("_acme-challenge.example.com")

--- a/tests/integration/alb/test_alb_update.py
+++ b/tests/integration/alb/test_alb_update.py
@@ -83,7 +83,7 @@ def test_duplicate_domain_check_ignores_self(client, dns, service_instance):
 
     client.update_alb_instance("4321", params={"domains": "example.com, foo.com"})
 
-    assert client.response.status_code == 202, client.response.body
+    assert client.response.status_code == 200, client.response.body
 
 
 def test_duplicate_domain_check_ignores_deactivated(client, dns, service_instance):
@@ -417,3 +417,8 @@ def subtest_update_removes_certificate_from_iam(tasks, iam_govcloud):
     iam_govcloud.assert_no_pending_responses()
     instance = ALBServiceInstance.query.get("4321")
     assert len(instance.certificates) == 1
+
+
+def subtest_update_noop(client):
+    client.update_alb_instance("4321", params={"domains": "bar.com, Foo.com"})
+    assert client.response.status_code == 200


### PR DESCRIPTION
## Changes proposed in this pull request:

-  when the domains are the same and the instance type is ALB, don't do anything on update

## Security considerations

None