### PR TITLE
Refactor cdn update parsing

### DIFF
--- a/broker/api.py
+++ b/broker/api.py
@@ -21,7 +21,6 @@ from openbrokerapi.service_broker import (
     UpdateServiceSpec,
 )
 from sap import cf_logging
-from sqlalchemy.dialects import postgresql
 
 
 from broker import validators

--- a/broker/api.py
+++ b/broker/api.py
@@ -293,7 +293,10 @@ class API(ServiceBroker):
             if "insecure_origin" in params:
                 origin_protocol_policy = "https-only"
                 if params["insecure_origin"]:
-                    if instance.cloudfront_origin_hostname == config.DEFAULT_CLOUDFRONT_ORIGIN:
+                    if (
+                        instance.cloudfront_origin_hostname
+                        == config.DEFAULT_CLOUDFRONT_ORIGIN
+                    ):
                         raise errors.ErrBadRequest(
                             "Cannot use insecure_origin with default origin"
                         )
@@ -317,7 +320,6 @@ class API(ServiceBroker):
         db.session.commit()
 
         queue(operation.id, cf_logging.FRAMEWORK.context.get_correlation_id())
-
 
         return UpdateServiceSpec(True, operation=str(operation.id))
 

--- a/broker/api.py
+++ b/broker/api.py
@@ -283,9 +283,8 @@ class API(ServiceBroker):
             if "forward_headers" in params:
                 forwarded_headers = parse_header_options(params)
             else:
-                # this is a weird way to do this, but if we _don't_ do this, sqlalchemy doesn't
-                # recognize that instance.forwarded_headers gets changed
-                forwarded_headers = [*instance.forwarded_headers]
+                # .copy() so sqlalchemy recognizes the field has changed
+                forwarded_headers = instance.forwarded_headers.copy()
             if instance.cloudfront_origin_hostname == config.DEFAULT_CLOUDFRONT_ORIGIN:
                 forwarded_headers.append("HOST")
             forwarded_headers = normalize_header_list(forwarded_headers)

--- a/broker/config.py
+++ b/broker/config.py
@@ -70,7 +70,7 @@ class AppConfig(Config):
         if not redis:
             raise MissingRedisError
 
-        self.REDIS_HOST = redis.credentials["HOST"]
+        self.REDIS_HOST = redis.credentials["host"]
         self.REDIS_PORT = redis.credentials["port"]
         self.REDIS_PASSWORD = redis.credentials["password"]
         self.ROUTE53_ZONE_ID = self.env("ROUTE53_ZONE_ID")

--- a/broker/config.py
+++ b/broker/config.py
@@ -70,7 +70,7 @@ class AppConfig(Config):
         if not redis:
             raise MissingRedisError
 
-        self.REDIS_HOST = redis.credentials["host"]
+        self.REDIS_HOST = redis.credentials["HOST"]
         self.REDIS_PORT = redis.credentials["port"]
         self.REDIS_PASSWORD = redis.credentials["password"]
         self.ROUTE53_ZONE_ID = self.env("ROUTE53_ZONE_ID")
@@ -200,6 +200,8 @@ class TestConfig(DockerConfig):
         self.ACME_POLL_TIMEOUT_IN_SECONDS = 10
         self.AWS_POLL_WAIT_TIME_IN_SECONDS = 1
         self.AWS_POLL_MAX_ATTEMPTS = 10
+        # if you need to see what sqlalchemy is doing
+        # self.SQLALCHEMY_ECHO = True
 
 
 class MissingRedisError(RuntimeError):

--- a/broker/models.py
+++ b/broker/models.py
@@ -54,7 +54,9 @@ class Certificate(Base):
     iam_server_certificate_id = db.Column(db.String)
     iam_server_certificate_name = db.Column(db.String)
     iam_server_certificate_arn = db.Column(db.String)
-    challenges = db.relation("Challenge", backref="certificate", lazy="dynamic", cascade="all, delete-orphan")
+    challenges = db.relation(
+        "Challenge", backref="certificate", lazy="dynamic", cascade="all, delete-orphan"
+    )
     order_json = db.Column(db.Text)
 
 

--- a/broker/tasks/pipelines.py
+++ b/broker/tasks/pipelines.py
@@ -242,7 +242,7 @@ def queue_all_cdn_update_tasks_for_operation(operation_id, correlation_id):
         )
         .then(
             iam.delete_previous_server_certificate,
-            operation_id, 
+            operation_id,
             correlation_id=correlation_id,
         )
         .then(

--- a/docker/start-servers.sh
+++ b/docker/start-servers.sh
@@ -17,7 +17,7 @@ if ! pgrep -x pebble > /dev/null; then
   echo "Starting Pebble"
   (
     cd /
-    pebble \
+    PEBBLE_WFE_NONCEREJECT=0 pebble \
       -config="/test/config/pebble-config.json" \
       -dnsserver="127.0.0.1:8053" \
       -strict \

--- a/tests/integration/alb/test_alb_provisioning.py
+++ b/tests/integration/alb/test_alb_provisioning.py
@@ -10,7 +10,10 @@ from broker.tasks.alb import get_lowest_used_alb
 from tests.lib.factories import ALBServiceInstanceFactory
 from tests.lib.client import check_last_operation_description
 
-from tests.integration.alb.test_alb_update import subtest_update_happy_path, subtest_update_noop
+from tests.integration.alb.test_alb_update import (
+    subtest_update_happy_path,
+    subtest_update_noop,
+)
 
 # The subtests below are "interesting".  Before test_provision_happy_path, we
 # had separate tests for each stage in the task pipeline.  But each test would
@@ -209,6 +212,7 @@ def test_provision_happy_path(
         client, dns, tasks, route53, iam_govcloud, simple_regex, alb
     )
     subtest_update_noop(client)
+
 
 def subtest_provision_creates_provision_operation(client, dns):
     dns.add_cname("_acme-challenge.example.com")

--- a/tests/integration/cdn/test_cdn_provisioning.py
+++ b/tests/integration/cdn/test_cdn_provisioning.py
@@ -176,7 +176,7 @@ def test_provision_sets_forward_headers_plus_host_when_some_specified(client, dn
     )
     instance = CDNServiceInstance.query.get("4321")
     assert sorted(instance.forwarded_headers) == sorted(
-        ["HOST", "x-my-header", "x-your-header"]
+        ["HOST", "X-MY-HEADER", "X-YOUR-HEADER"]
     )
 
 
@@ -478,7 +478,7 @@ def subtest_provision_creates_cloudfront_distribution(tasks, cloudfront):
         distribution_hostname="fake1234.cloudfront.net",
         forward_cookie_policy="whitelist",
         forwarded_cookies=["mycookie", "myothercookie"],
-        forwarded_headers=["x-my-header", "x-your-header"],
+        forwarded_headers=["X-MY-HEADER", "X-YOUR-HEADER"],
         origin_protocol_policy="http-only",
     )
 

--- a/tests/integration/cdn/test_cdn_update.py
+++ b/tests/integration/cdn/test_cdn_update.py
@@ -315,7 +315,7 @@ def test_update_sets_forward_headers_plus_host_when_some_specified(
     )
     instance = CDNServiceInstance.query.get("4321")
     assert sorted(instance.forwarded_headers) == sorted(
-        ["HOST", "x-my-header", "x-your-header"]
+        ["HOST", "X-MY-HEADER", "X-YOUR-HEADER"]
     )
 
 
@@ -559,7 +559,7 @@ def subtest_updates_cloudfront(tasks, cloudfront):
         distribution_hostname="fake1234.cloudfront.net",
         forward_cookie_policy="whitelist",
         forwarded_cookies=["mycookie", "myothercookie", "anewcookie"],
-        forwarded_headers=["x-my-header", "x-your-header"],
+        forwarded_headers=["X-MY-HEADER", "X-YOUR-HEADER"],
         origin_protocol_policy="http-only",
     )
 
@@ -608,9 +608,10 @@ def subtest_update_marks_update_complete(tasks):
     assert "succeeded" == operation.state
 
 
-
 def subtest_update_removes_certificate_from_iam(tasks, iam_commercial):
-    iam_commercial.expects_delete_server_certificate(f"4321-{date.today().isoformat()}-1")
+    iam_commercial.expects_delete_server_certificate(
+        f"4321-{date.today().isoformat()}-1"
+    )
 
     tasks.run_queued_tasks_and_enqueue_dependents()
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- refactor update and provisioning logic for CDN to prep for no-op checks and to share more logic
- disable random nonce-rejection from pebble test server. The thinking here is that we have sufficient retries in production, but the way we retry in production isn't reflected in our local tests, so injecting the failures into local testing just makes tests flaky

## Security considerations

None