### PR TITLE
skip all the certificate work if the domain names haven't changed

### DIFF
--- a/broker/api.py
+++ b/broker/api.py
@@ -253,6 +253,8 @@ class API(ServiceBroker):
             self.logger.info("validating unique domains")
             validators.UniqueDomains(domain_names).validate(instance)
             noop = noop and (sorted(domain_names) == sorted(instance.domain_names))
+            if instance.instance_type == "cdn_service_instance" and noop:
+                instance.new_certificate = instance.current_certificate
             instance.domain_names = domain_names
 
         if instance.instance_type == "cdn_service_instance":

--- a/broker/tasks/iam.py
+++ b/broker/tasks/iam.py
@@ -29,6 +29,9 @@ def upload_server_certificate(operation_id: int, **kwargs):
     else:
         iam = iam_govcloud
         iam_server_certificate_prefix = config.ALB_IAM_SERVER_CERTIFICATE_PREFIX
+
+    if service_instance.new_certificate.iam_server_certificate_arn is not None:
+        return
     certificate.iam_server_certificate_name = (
         f"{service_instance.id}-{today}-{certificate.id}"
     )
@@ -41,6 +44,9 @@ def upload_server_certificate(operation_id: int, **kwargs):
             CertificateChain=certificate.fullchain_pem,
         )
     except ClientError as e:
+        # TODO: there's an edge case here, where we uploaded the certificate but
+        # failed to persist the metadata to the database. If that happens, we really
+        # need to get the metadata back from IAM.
         if (
             e.response["Error"]["Code"] == "EntityAlreadyExistsException"
             and certificate.iam_server_certificate_id is not None

--- a/tests/integration/cdn/test_cdn_provisioning.py
+++ b/tests/integration/cdn/test_cdn_provisioning.py
@@ -8,7 +8,10 @@ from broker.models import Challenge, Operation, CDNServiceInstance
 from tests.lib.factories import CDNServiceInstanceFactory
 from tests.lib.client import check_last_operation_description
 
-from tests.integration.cdn.test_cdn_update import subtest_update_happy_path
+from tests.integration.cdn.test_cdn_update import (
+    subtest_update_happy_path,
+    subtest_update_same_domains,
+)
 
 # The subtests below are "interesting".  Before test_provision_happy_path, we
 # had separate tests for each stage in the task pipeline.  But each test would
@@ -276,6 +279,9 @@ def test_provision_happy_path(
     subtest_provision_marks_operation_as_succeeded(tasks)
     check_last_operation_description(client, "4321", operation_id, "Complete!")
     subtest_update_happy_path(
+        client, dns, tasks, route53, iam_commercial, simple_regex, cloudfront
+    )
+    subtest_update_same_domains(
         client, dns, tasks, route53, iam_commercial, simple_regex, cloudfront
     )
 

--- a/tests/integration/test_iam_idempotent.py
+++ b/tests/integration/test_iam_idempotent.py
@@ -100,11 +100,5 @@ def test_reupload_certificate_ok(
     db.session.expunge_all()
     service_instance = CDNServiceInstance.query.get("1234")
     certificate = service_instance.new_certificate
-    iam_commercial.expect_upload_server_certificate_raising_duplicate(
-        name=f"{service_instance.id}-{today}-{certificate.id}",
-        cert=certificate.leaf_pem,
-        private_key=certificate.private_key_pem,
-        chain=certificate.fullchain_pem,
-        path="/cloudfront/external-domains-test/",
-    )
+    # unstubbed, so an error should be raised if we do try
     upload_server_certificate.call_local("4321")


### PR DESCRIPTION
## Changes proposed in this pull request:

- Skip certificate updates when there's no change in domains

I think I'm going to skip the rest of the no-op work for now, because:
- it doesn't seem to add a ton of value (calling update on a cloudfront instance is free and not rate-limited)
- it would take quite a bit to test
- being able to issue an update that is theoretically no-op seems potentially useful in the future

closes #149 

## Security considerations

None