### PR TITLE
add logging to cloudfront distributions

### DIFF
--- a/broker/config.py
+++ b/broker/config.py
@@ -64,6 +64,7 @@ class AppConfig(Config):
         self.AWS_GOVCLOUD_REGION = self.env("AWS_GOVCLOUD_REGION")
         self.AWS_GOVCLOUD_ACCESS_KEY_ID = self.env("AWS_GOVCLOUD_ACCESS_KEY_ID")
         self.AWS_GOVCLOUD_SECRET_ACCESS_KEY = self.env("AWS_GOVCLOUD_SECRET_ACCESS_KEY")
+        self.CDN_LOG_BUCKET = self.env("CDN_LOG_BUCKET")
 
         redis = self.cfenv.get_service(label=re.compile("redis.*"))
 
@@ -173,6 +174,7 @@ class DockerConfig(Config):
         self.AWS_GOVCLOUD_REGION = "us-gov-west-1"
         self.AWS_GOVCLOUD_ACCESS_KEY_ID = "GOVCLOUD_FAKE_KEY_ID"
         self.AWS_GOVCLOUD_SECRET_ACCESS_KEY = "GOVCLOUD_FAKE_ACCESS_KEY"
+        self.CDN_LOG_BUCKET = "mybucket.s3.amazonaws.com"
 
         self.SMTP_HOST = "localhost"
         self.SMTP_PORT = 1025

--- a/broker/tasks/cloudfront.py
+++ b/broker/tasks/cloudfront.py
@@ -118,10 +118,10 @@ def create_distribution(operation_id: int, **kwargs):
             "CustomErrorResponses": {"Quantity": 0},
             "Comment": "external domain service https://cloud-gov/external-domain-broker",
             "Logging": {
-                "Enabled": False,
+                "Enabled": True,
                 "IncludeCookies": False,
-                "Bucket": "",
-                "Prefix": "",
+                "Bucket": config.CDN_LOG_BUCKET,
+                "Prefix": f"{service_instance.id}/",
             },
             "PriceClass": "PriceClass_100",
             "Enabled": True,

--- a/broker/tasks/cron.py
+++ b/broker/tasks/cron.py
@@ -93,7 +93,9 @@ def reschedule_operation(operation_id):
         elif operation.action == Operation.Actions.RENEW.value:
             pipelines.queue_all_cdn_renewal_tasks_for_service_instance(operation.id)
         elif operation.action == Operation.Actions.UPDATE.value:
-            pipelines.queue_all_cdn_update_tasks_for_operation(operation.id, "recovered_pipeline")
+            pipelines.queue_all_cdn_update_tasks_for_operation(
+                operation.id, "recovered_pipeline"
+            )
     elif service_instance.instance_type == "alb_service_instance":
         if operation.action == Operation.Actions.PROVISION.value:
             pipelines.queue_all_alb_provision_tasks_for_operation(
@@ -106,4 +108,6 @@ def reschedule_operation(operation_id):
         elif operation.action == Operation.Actions.RENEW.value:
             pipelines.queue_all_alb_renewal_tasks_for_service_instance(operation.id)
         elif operation.action == Operation.Actions.UPDATE.value:
-            pipelines.queue_all_alb_update_tasks_for_operation(operation.id, "recovered_pipeline")
+            pipelines.queue_all_alb_update_tasks_for_operation(
+                operation.id, "recovered_pipeline"
+            )

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -78,6 +78,7 @@ cf-manifest-env-dev: &cf-manifest-env-dev
     SMTP_PORT: ((smtp-port))
     SMTP_TO: ((smtp-to))
     SMTP_CERT: ((smtp-cert))
+    CDN_LOG_BUCKET: ((dev-log-bucket))
 
 cf-manifest-env-staging: &cf-manifest-env-staging
   environment_variables:
@@ -103,6 +104,7 @@ cf-manifest-env-staging: &cf-manifest-env-staging
     SMTP_PORT: ((smtp-port))
     SMTP_TO: ((smtp-to))
     SMTP_CERT: ((smtp-cert))
+    CDN_LOG_BUCKET: ((staging-log-bucket))
 
 cf-manifest-env-production: &cf-manifest-env-production
   environment_variables:
@@ -128,6 +130,7 @@ cf-manifest-env-production: &cf-manifest-env-production
     SMTP_PORT: ((smtp-port))
     SMTP_TO: ((smtp-to))
     SMTP_CERT: ((smtp-cert))
+    CDN_LOG_BUCKET: ((production-log-bucket))
 
 acceptance-tests-params-staging-alb: &acceptance-tests-params-staging-alb
   PLAN_NAME: "domain"

--- a/tests/integration/cdn/test_cdn_provisioning.py
+++ b/tests/integration/cdn/test_cdn_provisioning.py
@@ -486,7 +486,7 @@ def subtest_provision_creates_cloudfront_distribution(tasks, cloudfront):
         forwarded_cookies=["mycookie", "myothercookie"],
         forwarded_headers=["X-MY-HEADER", "X-YOUR-HEADER"],
         origin_protocol_policy="http-only",
-        bucket_prefix="4321/"
+        bucket_prefix="4321/",
     )
 
     tasks.run_queued_tasks_and_enqueue_dependents()

--- a/tests/integration/cdn/test_cdn_provisioning.py
+++ b/tests/integration/cdn/test_cdn_provisioning.py
@@ -486,6 +486,7 @@ def subtest_provision_creates_cloudfront_distribution(tasks, cloudfront):
         forwarded_cookies=["mycookie", "myothercookie"],
         forwarded_headers=["X-MY-HEADER", "X-YOUR-HEADER"],
         origin_protocol_policy="http-only",
+        bucket_prefix="4321/"
     )
 
     tasks.run_queued_tasks_and_enqueue_dependents()

--- a/tests/integration/cdn/test_cdn_renewals.py
+++ b/tests/integration/cdn/test_cdn_renewals.py
@@ -140,7 +140,7 @@ def subtest_updates_certificate_in_cloudfront(tasks, cloudfront: FakeCloudFront)
         origin_hostname="origin_hostname",
         origin_path="origin_path",
         distribution_id="FakeDistributionId",
-        bucket_prefix="4321/"
+        bucket_prefix="4321/",
     )
     cloudfront.expect_update_distribution(
         caller_reference="4321",
@@ -150,7 +150,7 @@ def subtest_updates_certificate_in_cloudfront(tasks, cloudfront: FakeCloudFront)
         origin_path="origin_path",
         distribution_id="FakeDistributionId",
         distribution_hostname="fake1234.cloudfront.net",
-        bucket_prefix="4321/"
+        bucket_prefix="4321/",
     )
 
     tasks.run_queued_tasks_and_enqueue_dependents()

--- a/tests/integration/cdn/test_cdn_renewals.py
+++ b/tests/integration/cdn/test_cdn_renewals.py
@@ -140,6 +140,7 @@ def subtest_updates_certificate_in_cloudfront(tasks, cloudfront: FakeCloudFront)
         origin_hostname="origin_hostname",
         origin_path="origin_path",
         distribution_id="FakeDistributionId",
+        bucket_prefix="4321/"
     )
     cloudfront.expect_update_distribution(
         caller_reference="4321",
@@ -149,6 +150,7 @@ def subtest_updates_certificate_in_cloudfront(tasks, cloudfront: FakeCloudFront)
         origin_path="origin_path",
         distribution_id="FakeDistributionId",
         distribution_hostname="fake1234.cloudfront.net",
+        bucket_prefix="4321/"
     )
 
     tasks.run_queued_tasks_and_enqueue_dependents()

--- a/tests/integration/cdn/test_cdn_update.py
+++ b/tests/integration/cdn/test_cdn_update.py
@@ -548,7 +548,7 @@ def subtest_updates_cloudfront(tasks, cloudfront):
         origin_hostname="origin_hostname",
         origin_path="origin_path",
         distribution_id="FakeDistributionId",
-        bucket_prefix="4321/"
+        bucket_prefix="4321/",
     )
     cloudfront.expect_update_distribution(
         caller_reference="4321",
@@ -562,7 +562,7 @@ def subtest_updates_cloudfront(tasks, cloudfront):
         forwarded_cookies=["mycookie", "myothercookie", "anewcookie"],
         forwarded_headers=["X-MY-HEADER", "X-YOUR-HEADER"],
         origin_protocol_policy="http-only",
-        bucket_prefix="4321/"
+        bucket_prefix="4321/",
     )
 
     tasks.run_queued_tasks_and_enqueue_dependents()
@@ -710,7 +710,7 @@ def subtest_update_same_domains_updates_cloudfront(tasks, cloudfront):
         origin_hostname="origin_hostname",
         origin_path="origin_path",
         distribution_id="FakeDistributionId",
-        bucket_prefix="4321/"
+        bucket_prefix="4321/",
     )
     cloudfront.expect_update_distribution(
         caller_reference="4321",
@@ -724,7 +724,7 @@ def subtest_update_same_domains_updates_cloudfront(tasks, cloudfront):
         forwarded_cookies=["mycookie", "myothercookie", "anewcookie"],
         forwarded_headers=["X-MY-HEADER", "X-YOUR-HEADER"],
         origin_protocol_policy="http-only",
-        bucket_prefix="4321/"
+        bucket_prefix="4321/",
     )
 
     tasks.run_queued_tasks_and_enqueue_dependents()

--- a/tests/integration/cdn/test_cdn_update.py
+++ b/tests/integration/cdn/test_cdn_update.py
@@ -548,6 +548,7 @@ def subtest_updates_cloudfront(tasks, cloudfront):
         origin_hostname="origin_hostname",
         origin_path="origin_path",
         distribution_id="FakeDistributionId",
+        bucket_prefix="4321/"
     )
     cloudfront.expect_update_distribution(
         caller_reference="4321",
@@ -561,6 +562,7 @@ def subtest_updates_cloudfront(tasks, cloudfront):
         forwarded_cookies=["mycookie", "myothercookie", "anewcookie"],
         forwarded_headers=["X-MY-HEADER", "X-YOUR-HEADER"],
         origin_protocol_policy="http-only",
+        bucket_prefix="4321/"
     )
 
     tasks.run_queued_tasks_and_enqueue_dependents()
@@ -708,6 +710,7 @@ def subtest_update_same_domains_updates_cloudfront(tasks, cloudfront):
         origin_hostname="origin_hostname",
         origin_path="origin_path",
         distribution_id="FakeDistributionId",
+        bucket_prefix="4321/"
     )
     cloudfront.expect_update_distribution(
         caller_reference="4321",
@@ -721,6 +724,7 @@ def subtest_update_same_domains_updates_cloudfront(tasks, cloudfront):
         forwarded_cookies=["mycookie", "myothercookie", "anewcookie"],
         forwarded_headers=["X-MY-HEADER", "X-YOUR-HEADER"],
         origin_protocol_policy="http-only",
+        bucket_prefix="4321/"
     )
 
     tasks.run_queued_tasks_and_enqueue_dependents()

--- a/tests/integration/test_cloudfront_idempotency.py
+++ b/tests/integration/test_cloudfront_idempotency.py
@@ -103,7 +103,7 @@ def test_create_distribution_referencing_nonexistent_distribution(
         origin_path=service_instance.cloudfront_origin_path,
         distribution_id="FakeDistributionId",
         distribution_hostname="fake1234.cloudfront.net",
-        bucket_prefix="1234/"
+        bucket_prefix="1234/",
     )
 
     create_distribution.call_local(provision_operation.id)

--- a/tests/integration/test_cloudfront_idempotency.py
+++ b/tests/integration/test_cloudfront_idempotency.py
@@ -103,6 +103,7 @@ def test_create_distribution_referencing_nonexistent_distribution(
         origin_path=service_instance.cloudfront_origin_path,
         distribution_id="FakeDistributionId",
         distribution_hostname="fake1234.cloudfront.net",
+        bucket_prefix="1234/"
     )
 
     create_distribution.call_local(provision_operation.id)

--- a/tests/lib/fake_cloudfront.py
+++ b/tests/lib/fake_cloudfront.py
@@ -21,7 +21,7 @@ class FakeCloudFront(FakeAWS):
         forwarded_cookies: list = None,
         forwarded_headers: list = None,
         origin_protocol_policy: str = "https-only",
-        bucket_prefix: str = ""
+        bucket_prefix: str = "",
     ):
         if forwarded_headers is None:
             forwarded_headers = ["HOST"]
@@ -39,7 +39,7 @@ class FakeCloudFront(FakeAWS):
                 forwarded_cookies=forwarded_cookies,
                 forwarded_headers=forwarded_headers,
                 origin_protocol_policy=origin_protocol_policy,
-                bucket_prefix=bucket_prefix
+                bucket_prefix=bucket_prefix,
             ),
             {
                 "DistributionConfig": self._distribution_config(
@@ -52,7 +52,7 @@ class FakeCloudFront(FakeAWS):
                     forwarded_cookies=forwarded_cookies,
                     forwarded_headers=forwarded_headers,
                     origin_protocol_policy=origin_protocol_policy,
-                    bucket_prefix=bucket_prefix
+                    bucket_prefix=bucket_prefix,
                 )
             },
         )
@@ -87,7 +87,7 @@ class FakeCloudFront(FakeAWS):
                     forwarded_cookies=forwarded_cookies,
                     forwarded_headers=forwarded_headers,
                     origin_protocol_policy=origin_protocol_policy,
-                    bucket_prefix=bucket_prefix
+                    bucket_prefix=bucket_prefix,
                 ),
                 "ETag": self.etag,
             },
@@ -170,7 +170,7 @@ class FakeCloudFront(FakeAWS):
         forwarded_cookies: list = None,
         forwarded_headers: list = None,
         origin_protocol_policy: str = "https-only",
-                bucket_prefix: str = "",
+        bucket_prefix: str = "",
     ):
         if forwarded_headers is None:
             forwarded_headers = ["HOST"]
@@ -189,7 +189,7 @@ class FakeCloudFront(FakeAWS):
             forwarded_cookies=forwarded_cookies,
             forwarded_headers=forwarded_headers,
             origin_protocol_policy=origin_protocol_policy,
-                bucket_prefix=bucket_prefix
+            bucket_prefix=bucket_prefix,
         )
         distribution["ETag"] = self.etag
         self.stubber.add_response(
@@ -220,7 +220,7 @@ class FakeCloudFront(FakeAWS):
         forwarded_cookies: list = None,
         forwarded_headers: list = None,
         origin_protocol_policy: str = "https-only",
-                bucket_prefix: str = "",
+        bucket_prefix: str = "",
     ):
         if forwarded_headers is None:
             forwarded_headers = ["HOST"]
@@ -238,7 +238,7 @@ class FakeCloudFront(FakeAWS):
                 forwarded_cookies=forwarded_cookies,
                 forwarded_headers=forwarded_headers,
                 origin_protocol_policy=origin_protocol_policy,
-                bucket_prefix=bucket_prefix
+                bucket_prefix=bucket_prefix,
             ),
             {
                 "DistributionConfig": self._distribution_config(
@@ -251,7 +251,7 @@ class FakeCloudFront(FakeAWS):
                     forwarded_cookies=forwarded_cookies,
                     forwarded_headers=forwarded_headers,
                     origin_protocol_policy=origin_protocol_policy,
-                bucket_prefix=bucket_prefix
+                    bucket_prefix=bucket_prefix,
                 ),
                 "Id": distribution_id,
                 "IfMatch": self.etag,
@@ -371,7 +371,7 @@ class FakeCloudFront(FakeAWS):
         forwarded_cookies: list = None,
         forwarded_headers: list = None,
         origin_protocol_policy: str = "https-only",
-                bucket_prefix: str = "",
+        bucket_prefix: str = "",
     ) -> Dict[str, Any]:
         if forwarded_headers is None:
             forwarded_headers = ["HOST"]

--- a/tests/lib/fake_cloudfront.py
+++ b/tests/lib/fake_cloudfront.py
@@ -21,6 +21,7 @@ class FakeCloudFront(FakeAWS):
         forwarded_cookies: list = None,
         forwarded_headers: list = None,
         origin_protocol_policy: str = "https-only",
+        bucket_prefix: str = ""
     ):
         if forwarded_headers is None:
             forwarded_headers = ["HOST"]
@@ -38,6 +39,7 @@ class FakeCloudFront(FakeAWS):
                 forwarded_cookies=forwarded_cookies,
                 forwarded_headers=forwarded_headers,
                 origin_protocol_policy=origin_protocol_policy,
+                bucket_prefix=bucket_prefix
             ),
             {
                 "DistributionConfig": self._distribution_config(
@@ -50,6 +52,7 @@ class FakeCloudFront(FakeAWS):
                     forwarded_cookies=forwarded_cookies,
                     forwarded_headers=forwarded_headers,
                     origin_protocol_policy=origin_protocol_policy,
+                    bucket_prefix=bucket_prefix
                 )
             },
         )
@@ -66,6 +69,7 @@ class FakeCloudFront(FakeAWS):
         forwarded_cookies: list = None,
         forwarded_headers: list = None,
         origin_protocol_policy: str = "https-only",
+        bucket_prefix: str = "",
     ):
         if forwarded_headers is None:
             forwarded_headers = ["HOST"]
@@ -83,6 +87,7 @@ class FakeCloudFront(FakeAWS):
                     forwarded_cookies=forwarded_cookies,
                     forwarded_headers=forwarded_headers,
                     origin_protocol_policy=origin_protocol_policy,
+                    bucket_prefix=bucket_prefix
                 ),
                 "ETag": self.etag,
             },
@@ -165,6 +170,7 @@ class FakeCloudFront(FakeAWS):
         forwarded_cookies: list = None,
         forwarded_headers: list = None,
         origin_protocol_policy: str = "https-only",
+                bucket_prefix: str = "",
     ):
         if forwarded_headers is None:
             forwarded_headers = ["HOST"]
@@ -183,6 +189,7 @@ class FakeCloudFront(FakeAWS):
             forwarded_cookies=forwarded_cookies,
             forwarded_headers=forwarded_headers,
             origin_protocol_policy=origin_protocol_policy,
+                bucket_prefix=bucket_prefix
         )
         distribution["ETag"] = self.etag
         self.stubber.add_response(
@@ -213,6 +220,7 @@ class FakeCloudFront(FakeAWS):
         forwarded_cookies: list = None,
         forwarded_headers: list = None,
         origin_protocol_policy: str = "https-only",
+                bucket_prefix: str = "",
     ):
         if forwarded_headers is None:
             forwarded_headers = ["HOST"]
@@ -230,6 +238,7 @@ class FakeCloudFront(FakeAWS):
                 forwarded_cookies=forwarded_cookies,
                 forwarded_headers=forwarded_headers,
                 origin_protocol_policy=origin_protocol_policy,
+                bucket_prefix=bucket_prefix
             ),
             {
                 "DistributionConfig": self._distribution_config(
@@ -242,6 +251,7 @@ class FakeCloudFront(FakeAWS):
                     forwarded_cookies=forwarded_cookies,
                     forwarded_headers=forwarded_headers,
                     origin_protocol_policy=origin_protocol_policy,
+                bucket_prefix=bucket_prefix
                 ),
                 "Id": distribution_id,
                 "IfMatch": self.etag,
@@ -260,6 +270,7 @@ class FakeCloudFront(FakeAWS):
         forwarded_cookies: list = None,
         forwarded_headers: list = None,
         origin_protocol_policy: str = "https-only",
+        bucket_prefix: str = "",
     ) -> Dict[str, Any]:
         if forwarded_headers is None:
             forwarded_headers = ["HOST"]
@@ -329,10 +340,10 @@ class FakeCloudFront(FakeAWS):
             "CustomErrorResponses": {"Quantity": 0},
             "Comment": "external domain service https://cloud-gov/external-domain-broker",
             "Logging": {
-                "Enabled": False,
+                "Enabled": True,
                 "IncludeCookies": False,
-                "Bucket": "",
-                "Prefix": "",
+                "Bucket": "mybucket.s3.amazonaws.com",
+                "Prefix": bucket_prefix,
             },
             "PriceClass": "PriceClass_100",
             "Enabled": enabled,
@@ -360,6 +371,7 @@ class FakeCloudFront(FakeAWS):
         forwarded_cookies: list = None,
         forwarded_headers: list = None,
         origin_protocol_policy: str = "https-only",
+                bucket_prefix: str = "",
     ) -> Dict[str, Any]:
         if forwarded_headers is None:
             forwarded_headers = ["HOST"]
@@ -389,6 +401,7 @@ class FakeCloudFront(FakeAWS):
                     forwarded_cookies,
                     forwarded_headers,
                     origin_protocol_policy,
+                    bucket_prefix,
                 ),
             }
         }

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -95,6 +95,7 @@ def mocked_env(monkeypatch, vcap_application, vcap_services):
     monkeypatch.setenv("SMTP_FROM", "no-reply@example.com")
     monkeypatch.setenv("SMTP_TO", "alerts@example.com")
     monkeypatch.setenv("SMTP_CERT", "A_REAL_CERT_WOULD_BE_LONGER_THAN_THIS")
+    monkeypatch.setenv("CDN_LOG_BUCKET", "my-bucket.s3.amazonaws.com")
 
 
 @pytest.mark.parametrize("env", ["production", "staging", "development"])
@@ -116,6 +117,16 @@ def test_config_gets_cf_origin_from_env(env, monkeypatch, mocked_env):
     config = config_from_env()
 
     assert config.DEFAULT_CLOUDFRONT_ORIGIN == "foo"
+
+
+@pytest.mark.parametrize("env", ["production", "staging", "development"])
+def test_config_gets_log_bucket_from_env(env, monkeypatch, mocked_env):
+    monkeypatch.setenv("FLASK_ENV", env)
+    monkeypatch.setenv("CDN_LOG_BUCKET", "foo")
+
+    config = config_from_env()
+
+    assert config.CDN_LOG_BUCKET == "foo"
 
 
 @pytest.mark.parametrize("env", ["development"])


### PR DESCRIPTION
fixes #135

## Changes proposed in this pull request:

- Add logging to cdn distributions

depends on cloud-gov/cg-provision#770

## Security considerations

None