### PR TITLE
delete new and current certificate when cleaning up

### DIFF
--- a/broker/tasks/iam.py
+++ b/broker/tasks/iam.py
@@ -80,12 +80,27 @@ def delete_server_certificate(operation_id: str, **kwargs):
     else:
         iam = iam_govcloud
 
-    try:
-        iam.delete_server_certificate(
-            ServerCertificateName=service_instance.current_certificate.iam_server_certificate_name
-        )
-    except iam_commercial.exceptions.NoSuchEntityException:
-        return
+    if (
+        service_instance.new_certificate is not None
+        and service_instance.new_certificate.iam_server_certificate_name is not None
+    ):
+        try:
+            iam.delete_server_certificate(
+                ServerCertificateName=service_instance.new_certificate.iam_server_certificate_name
+            )
+        except iam_commercial.exceptions.NoSuchEntityException:
+            pass
+
+    if (
+        service_instance.current_certificate is not None
+        and service_instance.current_certificate.iam_server_certificate_name is not None
+    ):
+        try:
+            iam.delete_server_certificate(
+                ServerCertificateName=service_instance.current_certificate.iam_server_certificate_name
+            )
+        except iam_commercial.exceptions.NoSuchEntityException:
+            return
 
 
 @huey.retriable_task

--- a/tests/integration/alb/test_alb_deprovisioning.py
+++ b/tests/integration/alb/test_alb_deprovisioning.py
@@ -18,9 +18,12 @@ def service_instance():
     )
     new_cert = factories.CertificateFactory.create(
         service_instance=service_instance,
-        private_key_pem="SOMEPRIVATEKEY",
-        leaf_pem="SOMECERTPEM",
-        fullchain_pem="FULLCHAINOFSOMECERTPEM",
+        private_key_pem="NEWSOMEPRIVATEKEY",
+        leaf_pem="NEWSOMECERTPEM",
+        fullchain_pem="NEWFULLCHAINOFSOMECERTPEM",
+        iam_server_certificate_id="new_certificate_id",
+        iam_server_certificate_arn="new_certificate_arn",
+        iam_server_certificate_name="new_certificate_name",
         id=1002,
     )
     current_cert = factories.CertificateFactory.create(
@@ -169,6 +172,9 @@ def subtest_deprovision_removes_certificate_from_iam(
     tasks, service_instance, iam_govcloud
 ):
     service_instance = ALBServiceInstance.query.get("1234")
+    iam_govcloud.expects_delete_server_certificate(
+        service_instance.new_certificate.iam_server_certificate_name
+    )
     iam_govcloud.expects_delete_server_certificate(
         service_instance.current_certificate.iam_server_certificate_name
     )

--- a/tests/integration/cdn/test_cdn_deprovisioning.py
+++ b/tests/integration/cdn/test_cdn_deprovisioning.py
@@ -19,9 +19,12 @@ def service_instance():
     )
     new_cert = factories.CertificateFactory.create(
         service_instance=service_instance,
-        private_key_pem="SOMEPRIVATEKEY",
-        leaf_pem="SOMECERTPEM",
-        fullchain_pem="FULLCHAINOFSOMECERTPEM",
+        private_key_pem="NEWSOMEPRIVATEKEY",
+        leaf_pem="NEWSOMECERTPEM",
+        fullchain_pem="NEWFULLCHAINOFSOMECERTPEM",
+        iam_server_certificate_id="new_certificate_id",
+        iam_server_certificate_arn="new_certificate_arn",
+        iam_server_certificate_name="new_certificate_name",
         id=1002,
     )
     current_cert = factories.CertificateFactory.create(
@@ -343,6 +346,9 @@ def subtest_deprovision_removes_certificate_from_iam(
 ):
     service_instance = CDNServiceInstance.query.get("1234")
     iam_commercial.expects_delete_server_certificate(
+        service_instance.new_certificate.iam_server_certificate_name
+    )
+    iam_commercial.expects_delete_server_certificate(
         service_instance.current_certificate.iam_server_certificate_name
     )
     tasks.run_queued_tasks_and_enqueue_dependents()
@@ -353,6 +359,9 @@ def subtest_deprovision_removes_certificate_from_iam_when_missing(
     tasks, service_instance, iam_commercial
 ):
     service_instance = CDNServiceInstance.query.get("1234")
+    iam_commercial.expects_delete_server_certificate_returning_no_such_entity(
+        name=service_instance.new_certificate.iam_server_certificate_name
+    )
     iam_commercial.expects_delete_server_certificate_returning_no_such_entity(
         name=service_instance.current_certificate.iam_server_certificate_name
     )


### PR DESCRIPTION
fixes #138

## Changes proposed in this pull request:

- Delete both the new and current certificate when deprovisioning. This catches a case where someone deprovisions while provisioning, updating, or renewing, after uploading the server certificate but before updating the CDN or ALB

## Security considerations

None