### PR TITLE
fix CustomErrorResponse config

### DIFF
--- a/broker/tasks/cloudfront.py
+++ b/broker/tasks/cloudfront.py
@@ -45,7 +45,11 @@ def get_aliases(service_instance):
 def get_custom_error_responses(service_instance):
     items = []
     for code, page in service_instance.error_responses.items():
-        items.append({"ErrorCode": int(code), "ResponsePagePath": page})
+        # yes, ErrorCode is an int, and ResponseCode is a str. No, I don't know why.
+        # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudfront.html#CloudFront.Client.create_distribution
+        items.append(
+            {"ErrorCode": int(code), "ResponsePagePath": page, "ResponseCode": code}
+        )
     if items:
         return {"Quantity": len(items), "Items": items}
     else:
@@ -292,7 +296,6 @@ def update_distribution(operation_id: str, **kwargs):
     flag_modified(operation, "step_description")
     db.session.add(operation)
     db.session.commit()
-
 
     config_response = cloudfront.get_distribution_config(
         Id=service_instance.cloudfront_distribution_id

--- a/tests/integration/cdn/test_cdn_provisioning.py
+++ b/tests/integration/cdn/test_cdn_provisioning.py
@@ -504,8 +504,16 @@ def subtest_provision_creates_cloudfront_distribution(tasks, cloudfront):
         custom_error_responses={
             "Quantity": 2,
             "Items": [
-                {"ErrorCode": 404, "ResponsePagePath": "/errors/404.html"},
-                {"ErrorCode": 405, "ResponsePagePath": "/errors/405.html"},
+                {
+                    "ErrorCode": 404,
+                    "ResponsePagePath": "/errors/404.html",
+                    "ResponseCode": "404",
+                },
+                {
+                    "ErrorCode": 405,
+                    "ResponsePagePath": "/errors/405.html",
+                    "ResponseCode": "405",
+                },
             ],
         },
     )

--- a/tests/integration/cdn/test_cdn_update.py
+++ b/tests/integration/cdn/test_cdn_update.py
@@ -552,8 +552,16 @@ def subtest_updates_cloudfront(tasks, cloudfront):
         custom_error_responses={
             "Quantity": 2,
             "Items": [
-                {"ErrorCode": 404, "ResponsePagePath": "/errors/404.html"},
-                {"ErrorCode": 405, "ResponsePagePath": "/errors/405.html"},
+                {
+                    "ErrorCode": 404,
+                    "ResponsePagePath": "/errors/404.html",
+                    "ResponseCode": "404",
+                },
+                {
+                    "ErrorCode": 405,
+                    "ResponsePagePath": "/errors/405.html",
+                    "ResponseCode": "405",
+                },
             ],
         },
     )
@@ -573,8 +581,16 @@ def subtest_updates_cloudfront(tasks, cloudfront):
         custom_error_responses={
             "Quantity": 2,
             "Items": [
-                {"ErrorCode": 404, "ResponsePagePath": "/errors/404.html"},
-                {"ErrorCode": 405, "ResponsePagePath": "/errors/405.html"},
+                {
+                    "ErrorCode": 404,
+                    "ResponsePagePath": "/errors/404.html",
+                    "ResponseCode": "404",
+                },
+                {
+                    "ErrorCode": 405,
+                    "ResponsePagePath": "/errors/405.html",
+                    "ResponseCode": "405",
+                },
             ],
         },
     )
@@ -733,8 +749,16 @@ def subtest_update_same_domains_updates_cloudfront(tasks, cloudfront):
         custom_error_responses={
             "Quantity": 2,
             "Items": [
-                {"ErrorCode": 404, "ResponsePagePath": "/errors/404.html"},
-                {"ErrorCode": 405, "ResponsePagePath": "/errors/405.html"},
+                {
+                    "ErrorCode": 404,
+                    "ResponsePagePath": "/errors/404.html",
+                    "ResponseCode": "404",
+                },
+                {
+                    "ErrorCode": 405,
+                    "ResponsePagePath": "/errors/405.html",
+                    "ResponseCode": "405",
+                },
             ],
         },
     )

--- a/tests/lib/fake_cloudfront.py
+++ b/tests/lib/fake_cloudfront.py
@@ -134,7 +134,7 @@ class FakeCloudFront(FakeAWS):
                 origin_path,
                 distribution_id,
                 distribution_hostname,
-                custom_error_responses={"Quantity": 0}
+                custom_error_responses={"Quantity": 0},
             ),
             {
                 "DistributionConfig": self._distribution_config(
@@ -144,7 +144,7 @@ class FakeCloudFront(FakeAWS):
                     origin_hostname,
                     origin_path,
                     enabled=False,
-                    custom_error_responses={"Quantity": 0}
+                    custom_error_responses={"Quantity": 0},
                 ),
                 "Id": distribution_id,
                 "IfMatch": self.etag,


### PR DESCRIPTION
## Changes proposed in this pull request:

- fixes #164 
- CloudFront needs us to pass an ResponseCode along with a ResponsePagePath for CustomErrorResponses

## Security considerations

None