### PR TITLE
add header and error response validation

### DIFF
--- a/broker/api.py
+++ b/broker/api.py
@@ -147,6 +147,7 @@ class API(ServiceBroker):
 
             instance.forwarded_headers = forwarded_headers
             instance.error_responses = params.get("error_responses", {})
+            validators.ErrorResponseConfig(instance.error_responses).validate()
             if params.get("insecure_origin", False):
                 if params.get("origin") is None:
                     raise errors.ErrBadRequest(
@@ -305,8 +306,8 @@ class API(ServiceBroker):
                     origin_protocol_policy = "http-only"
                 instance.origin_protocol_policy = origin_protocol_policy
             if "error_responses" in params:
-                print("got error responses")
                 instance.error_responses = params["error_responses"]
+                validators.ErrorResponseConfig(instance.error_responses).validate()
 
             queue = queue_all_cdn_update_tasks_for_operation
         else:
@@ -378,6 +379,7 @@ def parse_header_options(params):
     else:
         forwarded_headers = forwarded_headers.replace(" ", "")
         forwarded_headers = forwarded_headers.split(",")
+    validators.HeaderList(forwarded_headers).validate()
     return forwarded_headers
 
 

--- a/tests/unit/test_error_response_validator.py
+++ b/tests/unit/test_error_response_validator.py
@@ -1,0 +1,28 @@
+import pytest
+from openbrokerapi import errors
+
+from broker.validators import ErrorResponseConfig
+
+
+@pytest.mark.parametrize("input", ["foo", 400, ["asdf", "qwer"]])
+def test_must_be_dict(input):
+    with pytest.raises(errors.ErrBadRequest):
+        ErrorResponseConfig(input).validate()
+
+
+@pytest.mark.parametrize("path", ["foo", "401", "202", "0404", 400, ["asdf", "qwer"]])
+def test_keys_must_be_valid_strings(path):
+    with pytest.raises(errors.ErrBadRequest):
+        ErrorResponseConfig({400: path}).validate()
+
+
+@pytest.mark.parametrize("path", ["", None, 400, ["asdf", "qwer"]])
+def test_values_must_be_strings(path):
+    with pytest.raises(errors.ErrBadRequest):
+        ErrorResponseConfig({"400": path}).validate()
+
+
+@pytest.mark.parametrize("path", [" /", "./", "index.html"])
+def test_paths_must_be_absolute(path):
+    with pytest.raises(errors.ErrBadRequest):
+        ErrorResponseConfig({"400": path}).validate()

--- a/tests/unit/test_header_validation.py
+++ b/tests/unit/test_header_validation.py
@@ -1,0 +1,14 @@
+import pytest
+from openbrokerapi import errors
+
+from broker.validators import HeaderList
+
+
+def test_empty_headers():
+    with pytest.raises(errors.ErrBadRequest):
+        HeaderList([""]).validate()
+
+
+def test_valid_headers():
+    HeaderList(["foo", "foo-bar", "###", "*!"]).validate()
+    HeaderList([]).validate()


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add validator for headers
- Add validator for error_response

I'm copying the existing pattern of validator classes. I don't think it's at all necessary, especially for these simple validations, but the pattern is here, so why re-invent?


## Security considerations

None