### PR TITLE
get a new csr for renewals

### DIFF
--- a/broker/tasks/pipelines.py
+++ b/broker/tasks/pipelines.py
@@ -151,7 +151,8 @@ def queue_all_cdn_deprovision_tasks_for_operation(
 def queue_all_alb_renewal_tasks_for_service_instance(operation_id, **kwargs):
     correlation = {"correlation_id": "Renewal"}
     task_pipeline = (
-        letsencrypt.initiate_challenges.s(operation_id, **correlation)
+        letsencrypt.generate_private_key.s(operation_id, **correlation)
+        .then(letsencrypt.initiate_challenges, operation_id, **correlation)
         .then(route53.create_TXT_records, operation_id, **correlation)
         .then(route53.wait_for_changes, operation_id, **correlation)
         .then(letsencrypt.answer_challenges, operation_id, **correlation)
@@ -171,7 +172,8 @@ def queue_all_alb_renewal_tasks_for_service_instance(operation_id, **kwargs):
 def queue_all_cdn_renewal_tasks_for_service_instance(operation_id, **kwargs):
     correlation = {"correlation_id": "Renewal"}
     task_pipeline = (
-        letsencrypt.initiate_challenges.s(operation_id, **correlation)
+        letsencrypt.generate_private_key.s(operation_id, **correlation)
+        .then(letsencrypt.initiate_challenges, operation_id, **correlation)
         .then(route53.create_TXT_records, operation_id, **correlation)
         .then(route53.wait_for_changes, operation_id, **correlation)
         .then(letsencrypt.answer_challenges, operation_id, **correlation)

--- a/tests/integration/alb/test_alb_renewals.py
+++ b/tests/integration/alb/test_alb_renewals.py
@@ -21,6 +21,9 @@ from tests.integration.alb.test_alb_provisioning import (
     subtest_provision_provisions_ALIAS_records,
     subtest_provision_marks_operation_as_succeeded,
 )
+from tests.integration.alb.test_alb_update import (
+    subtest_update_creates_private_key_and_csr,
+)
 from tests.lib.factories import (
     ALBServiceInstanceFactory,
     OperationFactory,
@@ -114,6 +117,7 @@ def test_scan_for_expiring_certs_alb_happy_path(
     dns.add_cname("_acme-challenge.foo.com")
 
     subtest_queues_tasks()
+    subtest_update_creates_private_key_and_csr(tasks)
     subtest_provision_initiates_LE_challenge(tasks)
     subtest_provision_updates_TXT_records(tasks, route53)
     subtest_provision_waits_for_route53_changes(tasks, route53)

--- a/tests/integration/cdn/test_cdn_renewals.py
+++ b/tests/integration/cdn/test_cdn_renewals.py
@@ -17,6 +17,9 @@ from tests.integration.cdn.test_cdn_provisioning import (
     subtest_provision_uploads_certificate_to_iam,
     subtest_provision_marks_operation_as_succeeded,
 )
+from tests.integration.cdn.test_cdn_update import (
+    subtest_update_creates_private_key_and_csr,
+)
 from tests.lib.factories import (
     CDNServiceInstanceFactory,
     CertificateFactory,
@@ -111,6 +114,7 @@ def test_scan_for_expiring_certs_cdn_happy_path(
     dns.add_cname("_acme-challenge.foo.com")
 
     subtest_queues_tasks()
+    subtest_update_creates_private_key_and_csr(tasks)
     subtest_provision_initiates_LE_challenge(tasks)
     subtest_provision_updates_TXT_records(tasks, route53)
     subtest_provision_waits_for_route53_changes(tasks, route53)


### PR DESCRIPTION
This is not strictly required by Let's Encrypt, but it's best practice
and the get challenges step was modified to assume it was done when the
update logic was added.

## Changes proposed in this pull request:

- Call the generate CSR step for renewals

## Security considerations

None