### PR TITLE
cancel updates and renewals, too

### DIFF
--- a/broker/tasks/update_operations.py
+++ b/broker/tasks/update_operations.py
@@ -65,7 +65,7 @@ def cancel_pending_provisioning(operation_id: str, **kwargs):
     service_instance = operation.service_instance
     for op in service_instance.operations:
         if (
-            op.action == Operation.Actions.PROVISION.value
+            op.action != Operation.Actions.DEPROVISION.value
             and op.state == Operation.States.IN_PROGRESS.value
         ):
             op.canceled_at = datetime.utcnow()


### PR DESCRIPTION
## Changes proposed in this pull request:

- instead of canceling provision operations, cancel anything that is not a deprovision operation. These were equivalent when this function was written, but are not anymore since we have update and renewal operations now.

## Security considerations

None