### PR TITLE
add some sleep time 

### DIFF
--- a/broker/config.py
+++ b/broker/config.py
@@ -96,7 +96,7 @@ class AppConfig(Config):
         self.SMTP_TO = self.env("SMTP_TO")
         self.SMTP_TLS = True
         self.RUN_CRON = self.env.int("INSTANCE_INDEX", default=1) == 0
-        self.IAM_CERTIFICATE_PROPOGATION_TIME = 30
+        self.IAM_CERTIFICATE_PROPAGATION_TIME = 30
 
 
 class ProductionConfig(AppConfig):
@@ -205,7 +205,7 @@ class TestConfig(DockerConfig):
         self.AWS_POLL_MAX_ATTEMPTS = 10
         # if you need to see what sqlalchemy is doing
         # self.SQLALCHEMY_ECHO = True
-        self.IAM_CERTIFICATE_PROPOGATION_TIME = 0
+        self.IAM_CERTIFICATE_PROPAGATION_TIME = 0
 
 
 class MissingRedisError(RuntimeError):

--- a/broker/config.py
+++ b/broker/config.py
@@ -96,6 +96,7 @@ class AppConfig(Config):
         self.SMTP_TO = self.env("SMTP_TO")
         self.SMTP_TLS = True
         self.RUN_CRON = self.env.int("INSTANCE_INDEX", default=1) == 0
+        self.IAM_CERTIFICATE_PROPOGATION_TIME = 30
 
 
 class ProductionConfig(AppConfig):
@@ -204,6 +205,7 @@ class TestConfig(DockerConfig):
         self.AWS_POLL_MAX_ATTEMPTS = 10
         # if you need to see what sqlalchemy is doing
         # self.SQLALCHEMY_ECHO = True
+        self.IAM_CERTIFICATE_PROPOGATION_TIME = 0
 
 
 class MissingRedisError(RuntimeError):

--- a/broker/tasks/alb.py
+++ b/broker/tasks/alb.py
@@ -100,6 +100,7 @@ def remove_certificate_from_alb(operation_id, **kwargs):
         )
     db.session.add(service_instance)
     db.session.commit()
+    time.sleep(config.IAM_CERTIFICATE_PROPAGATION_TIME)
 
 
 @huey.retriable_task

--- a/broker/tasks/iam.py
+++ b/broker/tasks/iam.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import date
+import time
 
 from botocore.exceptions import ClientError
 from sqlalchemy import and_
@@ -28,9 +29,11 @@ def upload_server_certificate(operation_id: int, **kwargs):
     if service_instance.instance_type == "cdn_service_instance":
         iam = iam_commercial
         iam_server_certificate_prefix = config.CLOUDFRONT_IAM_SERVER_CERTIFICATE_PREFIX
+        propagation_time = 0
     else:
         iam = iam_govcloud
         iam_server_certificate_prefix = config.ALB_IAM_SERVER_CERTIFICATE_PREFIX
+        propagation_time = config.IAM_CERTIFICATE_PROPOGATION_TIME
 
     if service_instance.new_certificate.iam_server_certificate_arn is not None:
         return
@@ -66,6 +69,7 @@ def upload_server_certificate(operation_id: int, **kwargs):
     db.session.add(service_instance)
     db.session.add(certificate)
     db.session.commit()
+    time.sleep(propagation_time)
 
 
 @huey.retriable_task

--- a/broker/tasks/iam.py
+++ b/broker/tasks/iam.py
@@ -33,7 +33,7 @@ def upload_server_certificate(operation_id: int, **kwargs):
     else:
         iam = iam_govcloud
         iam_server_certificate_prefix = config.ALB_IAM_SERVER_CERTIFICATE_PREFIX
-        propagation_time = config.IAM_CERTIFICATE_PROPOGATION_TIME
+        propagation_time = config.IAM_CERTIFICATE_PROPAGATION_TIME
 
     if service_instance.new_certificate.iam_server_certificate_arn is not None:
         return


### PR DESCRIPTION
Right now, when we create a new ALB instance, we almost always get a failure when we go to add the certificate to the ALB, since IAM takes some time for consistency. This means that the task fails, then waits ten minutes before retrying. This tries to work around that by sleeping for 30 seconds after uploading an IAM certificate, only when working with ALB instances. 30 seconds is totally arbitrary.

The same thing happens when we delete a certificate - the first try fails because IAM thinks the ALB is still using it.

This could mean a 19 minute speedup in the alb portion of the smoke tests, which is currently the longer one at about 30 minutes.

## Changes proposed in this pull request:

-  Add some sleep time after uploading a certificate and after removing one.

## Security considerations

None