### PR TITLE
skip task signal logs

### DIFF
--- a/broker/tasks/huey.py
+++ b/broker/tasks/huey.py
@@ -60,17 +60,6 @@ def register_correlation_id(task):
     cf_logging.FRAMEWORK.context.set_correlation_id(correlation_id)
 
 
-@huey.signal()
-def log_task_transition(signal, task, exc=None):
-    args, kwargs = task.data
-    extra = dict(task_id=task.id, signal=signal)
-    if len(args):
-        extra["operation_id"] = args[0]
-    logger.info("task signal received", extra=extra)
-    if exc is not None:
-        logger.exception(msg="task raised exception", extra=extra, exc_info=exc)
-
-
 @huey.signal(signals.SIGNAL_ERROR)
 def mark_operation_failed(signal, task, exc=None):
     args, kwargs = task.data


### PR DESCRIPTION
## Changes proposed in this pull request:

- remove the `task signal received` logs, as they're never helpful

## Security considerations

None