### PR TITLE
Allow arrays for domains parameter

### DIFF
--- a/broker/api.py
+++ b/broker/api.py
@@ -388,6 +388,6 @@ def normalize_header_list(headers):
 def parse_domain_options(params):
     domains = params.get("domains", None)
     if isinstance(domains, str):
-        return [d.strip().lower() for d in domains.split(",")]
+        domains = domains.split(",")
     if isinstance(domains, list):
-        return domains
+        return [d.strip().lower() for d in domains]

--- a/tests/unit/test_provision.py
+++ b/tests/unit/test_provision.py
@@ -13,3 +13,4 @@ def test_parse_domains():
         "example.com",
         "example.gov",
     ]
+    assert api.parse_domain_options(dict(domains=["eXaMpLe.cOm   "])) == ["example.com"]

--- a/tests/unit/test_provision.py
+++ b/tests/unit/test_provision.py
@@ -1,0 +1,15 @@
+import pytest
+from broker import api
+
+
+def test_parse_domains():
+    assert api.parse_domain_options(dict(domains="example.com")) == ["example.com"]
+    assert api.parse_domain_options(dict(domains="example.com,example.gov")) == [
+        "example.com",
+        "example.gov",
+    ]
+    assert api.parse_domain_options(dict(domains=["example.com"])) == ["example.com"]
+    assert api.parse_domain_options(dict(domains=["example.com", "example.gov"])) == [
+        "example.com",
+        "example.gov",
+    ]


### PR DESCRIPTION
## Changes proposed in this pull request:

- We've had a few users bitten by this - arrays are the obvious choice for the domain parameter, but we went with comma-separated strings initially to be consistent with the old brokers. This change allows either

## Security considerations

None