### PR TITLE
add framework for updating service instance type

### DIFF
--- a/broker/api.py
+++ b/broker/api.py
@@ -76,10 +76,10 @@ class API(ServiceBroker):
                     description="Custom domain with TLS and CloudFront.",
                 ),
                 ServicePlan(
-                    id=MIGRATION_PLAN_ID, 
+                    id=MIGRATION_PLAN_ID,
                     name="migration-not-for-direct-use",
                     description="Migration plan for internal autmation.",
-                )
+                ),
             ],
         )
 
@@ -142,13 +142,14 @@ class API(ServiceBroker):
             instance = ALBServiceInstance(id=instance_id, domain_names=domain_names)
             queue = queue_all_alb_provision_tasks_for_operation
         elif details.plan_id == MIGRATION_PLAN_ID:
-            instance = MigrationServiceInstance(id=instance_id, domain_names=domain_names)
+            instance = MigrationServiceInstance(
+                id=instance_id, domain_names=domain_names
+            )
             db.session.add(instance)
             db.session.commit()
             return ProvisionedServiceSpec(state=ProvisionState.SUCCESSFUL_CREATED)
         else:
             raise NotImplementedError()
-
 
         self.logger.info("setting origin hostname")
         self.logger.info("creating operation")
@@ -377,6 +378,7 @@ def parse_domain_options(params):
     if isinstance(domains, list):
         return [d.strip().lower() for d in domains]
 
+
 def provision_cdn_instance(instance_id: str, domain_names: list, params: dict):
     instance = CDNServiceInstance(id=instance_id, domain_names=domain_names)
     queue = queue_all_cdn_provision_tasks_for_operation
@@ -401,11 +403,7 @@ def provision_cdn_instance(instance_id: str, domain_names: list, params: dict):
             raise errors.ErrBadRequest(
                 "'insecure_origin' cannot be set when using the default origin."
             )
-        instance.origin_protocol_policy = (
-            CDNServiceInstance.ProtocolPolicy.HTTP.value
-        )
+        instance.origin_protocol_policy = CDNServiceInstance.ProtocolPolicy.HTTP.value
     else:
-        instance.origin_protocol_policy = (
-            CDNServiceInstance.ProtocolPolicy.HTTPS.value
-        )
+        instance.origin_protocol_policy = CDNServiceInstance.ProtocolPolicy.HTTPS.value
     return instance

--- a/tests/integration/migration/test_migration_provisioning.py
+++ b/tests/integration/migration/test_migration_provisioning.py
@@ -48,7 +48,9 @@ def test_refuses_to_provision_with_duplicate_domains(client, dns):
     dns.add_cname("_acme-challenge.example.com")
     dns.add_cname("_acme-challenge.foo.com")
 
-    client.provision_migration_instance("4321", params={"domains": "example.com, foo.com"})
+    client.provision_migration_instance(
+        "4321", params={"domains": "example.com, foo.com"}
+    )
 
     assert "already exists" in client.response.body, client.response.body
     assert client.response.status_code == 400, client.response.body

--- a/tests/integration/test_plan_changes.py
+++ b/tests/integration/test_plan_changes.py
@@ -1,0 +1,89 @@
+"""
+These tests are about updating from one plan type to another
+"""
+from broker.extensions import config, db
+from broker.models import (
+    Challenge,
+    Operation,
+    CDNServiceInstance,
+    ALBServiceInstance,
+    ServiceInstance,
+    change_instance_type,
+    MigrationServiceInstance,
+)
+import pytest
+
+from tests.lib import factories
+
+
+@pytest.fixture
+def alb_instance(clean_db):
+    service_instance = factories.ALBServiceInstanceFactory.create(
+        id="started-as-alb-instance", domain_names=["example.com", "foo.com"],
+    )
+    return service_instance
+
+
+@pytest.fixture
+def migration_instance(clean_db):
+    service_instance = factories.MigrationServiceInstanceFactory.create(
+        id="started-as-migration-instance", domain_names=["example.com", "foo.com"],
+    )
+    return service_instance
+
+
+@pytest.fixture
+def cdn_instance(clean_db):
+    service_instance = factories.CDNServiceInstanceFactory.create(
+        id="started-as-cdn-instance",
+        domain_names=["example.com", "foo.com"],
+        domain_internal="fake1234.cloudfront.net",
+        route53_alias_hosted_zone="Z2FDTNDATAQYW2",
+        cloudfront_distribution_id="FakeDistributionId",
+        cloudfront_origin_hostname="origin_hostname",
+        cloudfront_origin_path="origin_path",
+        origin_protocol_policy="https-only",
+    )
+    return service_instance
+
+
+def test_refuses_if_new_type_not_serviceinstance(cdn_instance):
+    with pytest.raises(NotImplementedError):
+        change_instance_type(cdn_instance, Challenge, None)
+    with pytest.raises(NotImplementedError):
+        change_instance_type(cdn_instance, ServiceInstance, None)
+
+
+def test_refuses_if_not_serviceinstance():
+    with pytest.raises(NotImplementedError):
+        change_instance_type(Challenge(), ALBServiceInstance, None)
+
+
+def test_returns_instance_if_same_type(cdn_instance):
+    instance = change_instance_type(cdn_instance, CDNServiceInstance, None)
+    assert instance is cdn_instance
+
+
+def test_refuses_not_yet_implemented_transformations(
+    cdn_instance, migration_instance, alb_instance
+):
+    with pytest.raises(NotImplementedError):
+        change_instance_type(cdn_instance, ALBServiceInstance, None)
+    with pytest.raises(NotImplementedError):
+        change_instance_type(cdn_instance, MigrationServiceInstance, None)
+    with pytest.raises(NotImplementedError):
+        change_instance_type(alb_instance, CDNServiceInstance, None)
+    with pytest.raises(NotImplementedError):
+        change_instance_type(alb_instance, MigrationServiceInstance, None)
+    with pytest.raises(NotImplementedError):
+        change_instance_type(migration_instance, ALBServiceInstance, None)
+
+
+def test_migration_to_cdn(migration_instance, clean_db):
+    instance = change_instance_type(
+        migration_instance, CDNServiceInstance, clean_db.session
+    )
+    clean_db.session.expunge_all()
+    instance = CDNServiceInstance.query.get("started-as-migration-instance")
+    assert instance is not None
+    assert instance.domain_names == ["example.com", "foo.com"]

--- a/tests/lib/client.py
+++ b/tests/lib/client.py
@@ -97,7 +97,6 @@ class CFAPIClient(FlaskClient):
             query_string={"accepts_incomplete": accepts_incomplete},
         )
 
-
     def update_cdn_instance(
         self, id: str, accepts_incomplete: str = "true", params: dict = None
     ):

--- a/tests/lib/factories.py
+++ b/tests/lib/factories.py
@@ -9,6 +9,7 @@ from broker.models import (
     Operation,
     CDNServiceInstance,
     ALBServiceInstance,
+    MigrationServiceInstance,
 )
 
 
@@ -29,6 +30,13 @@ class CDNServiceInstanceFactory(BaseFactory):
 class ALBServiceInstanceFactory(BaseFactory):
     class Meta(object):
         model = ALBServiceInstance
+
+    id = Sequence(lambda n: "UUID {}".format(n))
+
+
+class MigrationServiceInstanceFactory(BaseFactory):
+    class Meta(object):
+        model = MigrationServiceInstance
 
     id = Sequence(lambda n: "UUID {}".format(n))
 


### PR DESCRIPTION
This is a little clumsy because, as far as I can tell, sqlalchemy won't
let us just directly convert a model type.

## Changes proposed in this pull request:

- add framework for updating service instance type

## Security considerations

None