### PR TITLE
Update renewal action name to "Renew"

### DIFF
--- a/docs/operational.md
+++ b/docs/operational.md
@@ -62,5 +62,5 @@ This could also be used to force an early renewal of a certificate:
 
 ```
 sql> INSERT INTO operation (service_instance_id, updated_at, action, state)
-        VALUES (<service_instance_id>, now(), 'Renewal', 'in progress');
+        VALUES (<service_instance_id>, now(), 'Renew', 'in progress');
 ```


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update ops docs Renewal action string to "Renew" and not "Renewal"

## Security considerations

None
