### PR TITLE
Allow updating migrator instances to alb instances

### DIFF
--- a/broker/api.py
+++ b/broker/api.py
@@ -44,6 +44,7 @@ from broker.tasks.pipelines import (
     queue_all_cdn_provision_tasks_for_operation,
     queue_all_cdn_update_tasks_for_operation,
     queue_all_cdn_broker_migration_tasks_for_operation,
+    queue_all_domain_broker_migration_tasks_for_operation,
 )
 
 ALB_PLAN_ID = "6f60835c-8964-4f1f-a19a-579fb27ce694"
@@ -317,6 +318,15 @@ class API(ServiceBroker):
                 update_cdn_params_for_migration(instance, params)
                 db.session.add(instance.current_certificate)
                 queue = queue_all_cdn_broker_migration_tasks_for_operation
+            elif details.plan_id == ALB_PLAN_ID:
+                noop = False
+                validate_migration_to_alb_params(params)
+                instance = change_instance_type(
+                    instance, ALBServiceInstance, db.session
+                )
+                update_alb_params_for_migration(instance, params)
+                db.session.add(instance.current_certificate)
+                queue = queue_all_domain_broker_migration_tasks_for_operation
             else:
                 raise ClientError("Updating to this service plan is not supported")
         if noop:
@@ -455,6 +465,40 @@ def validate_migration_to_cdn_params(params):
         # fair and smart to require all params
         if not param in params:
             raise ClientError(f"Missing parameter {param}")
+
+
+def validate_migration_to_alb_params(params):
+    required = [
+        "iam_server_certificate_name",
+        "iam_server_certificate_id",
+        "iam_server_certificate_arn",
+        "domain_internal",
+        "alb_arn",
+        "alb_listener_arn",
+        "hosted_zone_id",
+    ]
+    for param in required:
+        # since this should only be hit by another app, it seems
+        # fair and smart to require all params
+        if not param in params:
+            raise ClientError(f"Missing parameter {param}")
+
+
+def update_alb_params_for_migration(instance, params):
+    instance.current_certificate = Certificate(service_instance_id=instance.id)
+    instance.current_certificate.iam_server_certificate_id = params[
+        "iam_server_certificate_id"
+    ]
+    instance.current_certificate.iam_server_certificate_arn = params[
+        "iam_server_certificate_arn"
+    ]
+    instance.current_certificate.iam_server_certificate_name = params[
+        "iam_server_certificate_name"
+    ]
+    instance.domain_internal = params["domain_internal"]
+    instance.route53_alias_hosted_zone = params["hosted_zone_id"]
+    instance.alb_listener_arn = params["alb_listener_arn"]
+    instance.alb_arn = params["alb_arn"]
 
 
 def update_cdn_params_for_migration(instance, params):

--- a/broker/models.py
+++ b/broker/models.py
@@ -254,7 +254,5 @@ def change_instance_type(service_instance: ServiceInstance, new_type: type, sess
     if type(service_instance) == ALBServiceInstance:
         raise NotImplementedError()
     if type(service_instance) == MigrationServiceInstance:
-        if new_type == ALBServiceInstance:
-            raise NotImplementedError()
-        if new_type == CDNServiceInstance:
+        if new_type in (CDNServiceInstance, ALBServiceInstance):
             return clone_instance(service_instance, new_type, session)

--- a/broker/tasks/pipelines.py
+++ b/broker/tasks/pipelines.py
@@ -195,3 +195,28 @@ def queue_all_cdn_broker_migration_tasks_for_operation(operation_id, correlation
         .then(update_operations.provision, operation_id, **correlation)
     )
     huey.enqueue(task_pipeline)
+
+
+def queue_all_domain_broker_migration_tasks_for_operation(operation_id, correlation_id):
+    correlation = {"correlation_id": correlation_id}
+    task_pipeline = (
+        letsencrypt.create_user.s(operation_id, **correlation)
+        .then(letsencrypt.generate_private_key, operation_id, **correlation)
+        .then(letsencrypt.initiate_challenges, operation_id, **correlation)
+        # create alias records here is probably not necessary, but belt + suspenders
+        .then(route53.create_ALIAS_records, operation_id, **correlation)
+        .then(route53.wait_for_changes, operation_id, **correlation)
+        .then(route53.create_TXT_records, operation_id, **correlation)
+        .then(route53.wait_for_changes, operation_id, **correlation)
+        .then(letsencrypt.answer_challenges, operation_id, **correlation)
+        .then(letsencrypt.retrieve_certificate, operation_id, **correlation)
+        .then(iam.upload_server_certificate, operation_id, **correlation)
+        .then(alb.select_alb, operation_id, **correlation)
+        .then(alb.add_certificate_to_alb, operation_id, **correlation)
+        .then(route53.create_ALIAS_records, operation_id, **correlation)
+        .then(route53.wait_for_changes, operation_id, **correlation)
+        .then(alb.remove_certificate_from_previous_alb, operation_id, **correlation)
+        .then(iam.delete_previous_server_certificate, operation_id, **correlation)
+        .then(update_operations.provision, operation_id, **correlation)
+    )
+    huey.enqueue(task_pipeline)

--- a/tests/integration/migration/test_migration_update_to_alb.py
+++ b/tests/integration/migration/test_migration_update_to_alb.py
@@ -1,22 +1,131 @@
 import pytest
 
 from tests.lib import factories
+from tests.lib.client import check_last_operation_description
+from tests.integration.alb.test_alb_provisioning import (
+    subtest_provision_adds_certificate_to_alb,
+    subtest_provision_answers_challenges,
+    subtest_provision_creates_LE_user,
+    subtest_provision_initiates_LE_challenge,
+    subtest_provision_marks_operation_as_succeeded,
+    subtest_provision_provisions_ALIAS_records,
+    subtest_provision_retrieves_certificate,
+    subtest_provision_selects_alb,
+    subtest_provision_updates_TXT_records,
+    subtest_provision_uploads_certificate_to_iam,
+    subtest_provision_waits_for_route53_changes,
+)
+from tests.integration.alb.test_alb_update import (
+    subtest_update_creates_private_key_and_csr,
+)
+from tests.integration.alb.test_alb_renewals import (
+    subtest_renewal_removes_certificate_from_iam,
+    subtest_renewal_removes_certificate_from_alb,
+)
+
+from broker.models import ALBServiceInstance
 
 
 @pytest.fixture
 def migration_instance(clean_db):
-    service_instance = factories.CDNServiceInstanceFactory.create(
-        id="started-as-migration-instance", domain_names=["example.com", "foo.com"]
+    service_instance = factories.MigrationServiceInstanceFactory.create(
+        id="4321", domain_names=["example.com", "foo.com"]
     )
     return service_instance
 
 
-# yeah, a whole file for one test.
-# the idea is that later we're going to add this feature,
-# so this should make it easier to find and update this test
+@pytest.fixture
+def full_update_example():
+    # this one is used for the full pipeline test.
+    # it's kinda finicky because we are reusing other tests that assume some inputs
+    params = {}
+    params["iam_server_certificate_id"] = "certificate_id"
+    params["iam_server_certificate_arn"] = "certificate_arn"
+    params["iam_server_certificate_name"] = "certificate_name"
+    params["domain_internal"] = "alb.cloud.test"
+    params["alb_arn"] = "arn:aws:alb"
+    params["alb_listener_arn"] = "listener-arn-0"
+    params["hosted_zone_id"] = "ALBHOSTEDZONEID"
+    return params
 
 
-def test_cannot_update_migration_instance_to_alb(client, migration_instance):
-    client.update_instance_to_alb("started-as-migration-instance")
+@pytest.mark.parametrize(
+    "missing_param",
+    [
+        "iam_server_certificate_name",
+        "iam_server_certificate_id",
+        "iam_server_certificate_arn",
+        "alb_arn",
+        "alb_listener_arn",
+        "hosted_zone_id",
+        "domain_internal",
+    ],
+)
+def test_migration_update_fails_without_required_params(
+    client, migration_instance, missing_param, full_update_example
+):
+    full_update_example.pop(missing_param)
+    client.update_instance_to_alb("4321", params=full_update_example)
     assert client.response.status_code >= 400
-    assert "not supported" in client.response.json.get("description")
+    assert "missing" in client.response.json.get("description").lower()
+    assert missing_param in client.response.json.get("description")
+
+
+def test_can_update_migration_instance_to_alb(
+    client, migration_instance, full_update_example
+):
+    client.update_instance_to_alb("4321", params=full_update_example)
+    assert client.response.status_code == 202
+
+
+def test_migration_creates_certificate_record(
+    client, migration_instance, full_update_example, clean_db
+):
+    client.update_instance_to_alb("4321", params=full_update_example)
+    assert client.response.status_code == 202
+    clean_db.session.expunge_all()
+    instance = ALBServiceInstance.query.get("4321")
+    assert instance.current_certificate is not None
+    assert instance.current_certificate.iam_server_certificate_id == "certificate_id"
+    assert instance.current_certificate.iam_server_certificate_arn == "certificate_arn"
+    assert (
+        instance.current_certificate.iam_server_certificate_name == "certificate_name"
+    )
+    assert instance.domain_internal == "alb.cloud.test"
+    assert instance.route53_alias_hosted_zone == "ALBHOSTEDZONEID"
+    assert instance.alb_listener_arn is not None
+    assert instance.alb_arn is not None
+
+
+def test_migration_pipeline(
+    clean_db,
+    client,
+    tasks,
+    migration_instance,
+    route53,
+    dns,
+    iam_govcloud,
+    simple_regex,
+    full_update_example,
+    alb,
+):
+    dns.add_cname("_acme-challenge.example.com")
+    dns.add_cname("_acme-challenge.foo.com")
+    client.update_instance_to_alb("4321", params=full_update_example)
+    subtest_provision_creates_LE_user(tasks)
+    subtest_update_creates_private_key_and_csr(tasks)
+    subtest_provision_initiates_LE_challenge(tasks)
+    subtest_provision_provisions_ALIAS_records(tasks, route53, alb)
+    subtest_provision_waits_for_route53_changes(tasks, route53)
+    subtest_provision_updates_TXT_records(tasks, route53)
+    subtest_provision_waits_for_route53_changes(tasks, route53)
+    subtest_provision_answers_challenges(tasks, dns)
+    subtest_provision_retrieves_certificate(tasks)
+    subtest_provision_uploads_certificate_to_iam(tasks, iam_govcloud, simple_regex)
+    subtest_provision_selects_alb(tasks, alb)
+    subtest_provision_adds_certificate_to_alb(tasks, alb)
+    subtest_provision_provisions_ALIAS_records(tasks, route53, alb)
+    subtest_provision_waits_for_route53_changes(tasks, route53)
+    subtest_renewal_removes_certificate_from_alb(tasks, alb)
+    subtest_renewal_removes_certificate_from_iam(tasks, iam_govcloud)
+    subtest_provision_marks_operation_as_succeeded(tasks)

--- a/tests/integration/test_plan_changes.py
+++ b/tests/integration/test_plan_changes.py
@@ -75,8 +75,6 @@ def test_refuses_not_yet_implemented_transformations(
         change_instance_type(alb_instance, CDNServiceInstance, None)
     with pytest.raises(NotImplementedError):
         change_instance_type(alb_instance, MigrationServiceInstance, None)
-    with pytest.raises(NotImplementedError):
-        change_instance_type(migration_instance, ALBServiceInstance, None)
 
 
 def test_migration_to_cdn(migration_instance, clean_db):

--- a/tests/integration/test_stalled_operations.py
+++ b/tests/integration/test_stalled_operations.py
@@ -87,7 +87,9 @@ def test_does_not_find_canceled_operations(clean_db):
     assert scan_for_stalled_pipelines() == []
 
 
-@pytest.mark.parametrize("action", ["Provision", "Deprovision", "Renew", "Update", "Migrate to broker"])
+@pytest.mark.parametrize(
+    "action", ["Provision", "Deprovision", "Renew", "Update", "Migrate to broker"]
+)
 def test_reschedules_operation(clean_db, action):
     stalled_operation = factories.OperationFactory.create(
         id=1234, state="in progress", action=action


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add pipeline for migrator -> alb updates
- Change validators to allow updating migrator -> alb
- Add API steps to prep migrator for update to alb
- fixes #210 

## Security considerations

None