### PR TITLE
clean up new_certificate when retrieval fails due to validation errors

### DIFF
--- a/tests/integration/test_failing_tasks.py
+++ b/tests/integration/test_failing_tasks.py
@@ -68,7 +68,6 @@ def test_retry_tasks_marked_failed_only_after_last_retry():
     db.session.commit()
     with fallible_huey() as h:
         with immediate_huey() as h:
-            # this task should fail because we have not created a user
             task = retry_task("6789")
             with pytest.raises(TaskException):
                 result = task()


### PR DESCRIPTION

## Changes proposed in this pull request:

- clean up new_certificate when retrieval fails due to validation errors. When a validation fails, we need a new order and new challenges in order to retry. Because of this, we need to delete the service_instance.new_certificate record, so we don't try to reuse it

## Security considerations

None