### PR TITLE
sleep after we've determined we're not skipping the task

### DIFF
--- a/broker/tasks/alb.py
+++ b/broker/tasks/alb.py
@@ -119,9 +119,8 @@ def remove_certificate_from_previous_alb(operation_id, **kwargs):
     db.session.add(operation)
     db.session.commit()
 
-    time.sleep(int(config.DNS_PROPAGATION_SLEEP_TIME))
-
     if service_instance.previous_alb_listener_arn is not None:
+        time.sleep(int(config.DNS_PROPAGATION_SLEEP_TIME))
         alb.remove_listener_certificates(
             ListenerArn=service_instance.previous_alb_listener_arn,
             Certificates=[


### PR DESCRIPTION
## Changes proposed in this pull request:

- Wait until we've determined there's a cert to remove before we sleep. The sleep here is so we don't remove the cert until the DNS updates have propagated. 

## Security considerations

None