### PR TITLE
set service visibility correctly

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -7,7 +7,7 @@ broker-register-params: &broker-register-params
   BROKER_NAME: ((name))
   AUTH_USER: ((broker-auth-username))
   AUTH_PASS: ((broker-auth-password))
-  SERVICES: ((service-name))
+  SERVICES: ((visible-services))
 
 cf-creds-dev: &cf-creds-dev
   CF_API_URL: ((dev-cf-api-url))


### PR DESCRIPTION
## Changes proposed in this pull request:

- separate service-name from services so we can enable individual services. This way, we can disable visibility on the migration plan

## Security considerations

None