### PR TITLE
skip periodic tasks from the consumer

### DIFF
--- a/scripts/run-worker
+++ b/scripts/run-worker
@@ -5,5 +5,11 @@ shopt -s inherit_errexit
 
 export PYTHONPATH=$(dirname "$0")/..
 
+opts=""
+
+if [[ ! ${INSTANCE_INDEX:-0} = 0 ]]; then
+    opts="$opts --no-periodic"
+fi
+
 # send logs to dev null, since we create other log handlers elsewhere
-exec huey_consumer.py "$@" broker.huey_consumer.huey -l /dev/null
+exec huey_consumer.py "$@" $opts broker.huey_consumer.huey -l /dev/null 


### PR DESCRIPTION
## Changes proposed in this pull request:

- skip periodic tasks from the consumer. We currently do this via a config variable and a return statement in the cron tasks, and we're not removing that logic right now. The only reason to switch really is to quiet down the logs a bit. 

## Security considerations

None