### PR TITLE
Fix cdn provision tests

### DIFF
--- a/tests/integration/alb/test_alb_provisioning.py
+++ b/tests/integration/alb/test_alb_provisioning.py
@@ -111,7 +111,7 @@ def test_doesnt_refuse_to_provision_with_duplicate_domains_when_not_configured_t
     client.provision_cdn_instance("4321", params={"domains": "example.com, foo.com"})
 
     assert client.response.status_code == 202, client.response.body
-    config.IGNORE_DUPLICATE_DOMAINS
+    config.IGNORE_DUPLICATE_DOMAINS = False
 
 
 def test_duplicate_domain_check_ignores_deactivated(client, dns):

--- a/tests/integration/alb/test_alb_provisioning.py
+++ b/tests/integration/alb/test_alb_provisioning.py
@@ -111,7 +111,7 @@ def test_doesnt_refuse_to_provision_with_duplicate_domains_when_not_configured_t
     client.provision_cdn_instance("4321", params={"domains": "example.com, foo.com"})
 
     assert client.response.status_code == 202, client.response.body
-    config.IGNORE_DUPLICATE_DOMAINS = False
+    config.IGNORE_DUPLICATE_DOMAINS = old_ignore
 
 
 def test_duplicate_domain_check_ignores_deactivated(client, dns):

--- a/tests/integration/cdn/test_cdn_provisioning.py
+++ b/tests/integration/cdn/test_cdn_provisioning.py
@@ -65,7 +65,7 @@ def test_doesnt_refuse_to_provision_with_duplicate_domains_when_not_configured_t
     client.provision_cdn_instance("4321", params={"domains": "example.com, foo.com"})
 
     assert client.response.status_code == 202, client.response.body
-    config.IGNORE_DUPLICATE_DOMAINS = False
+    config.IGNORE_DUPLICATE_DOMAINS = old_ignore
 
 
 def test_duplicate_domain_check_ignores_deactivated(client, dns):

--- a/tests/integration/cdn/test_cdn_provisioning.py
+++ b/tests/integration/cdn/test_cdn_provisioning.py
@@ -54,6 +54,20 @@ def test_refuses_to_provision_with_duplicate_domains(client, dns):
     assert client.response.status_code == 400, client.response.body
 
 
+
+def test_doesnt_refuse_to_provision_with_duplicate_domains_when_not_configured_to(app, client, dns):
+    old_ignore = config.IGNORE_DUPLICATE_DOMAINS
+    config.IGNORE_DUPLICATE_DOMAINS = True
+    CDNServiceInstanceFactory.create(domain_names=["foo.com", "bar.com"])
+    dns.add_cname("_acme-challenge.example.com")
+    dns.add_cname("_acme-challenge.foo.com")
+
+    client.provision_cdn_instance("4321", params={"domains": "example.com, foo.com"})
+
+    assert client.response.status_code == 202, client.response.body
+    config.IGNORE_DUPLICATE_DOMAINS = False
+
+
 def test_duplicate_domain_check_ignores_deactivated(client, dns):
     CDNServiceInstanceFactory.create(
         domain_names="foo.com", deactivated_at=datetime.utcnow()


### PR DESCRIPTION
- reset config value at the end of the test
- add the test for CDNs too

## Changes proposed in this pull request:

- reset config value at the end of the test
- add the test for CDNs too

## Security considerations

None