### PR TITLE
Cascade does not apply to deletes on query objects

### DIFF
--- a/broker/duplicate_certs.py
+++ b/broker/duplicate_certs.py
@@ -43,9 +43,10 @@ def log_duplicate_alb_cert_metrics(logger=logger):
     logger.info(f"service_instance_cert_count{{service_instance_id=\"{service_instance_id}\"}} {num_duplicates}")
 
 def delete_duplicate_cert_db_record(duplicate_cert):
-    Certificate.query.filter(
+    certificate = Certificate.query.filter(
         Certificate.id == duplicate_cert.id
-    ).delete()
+    ).first()
+    db.session.delete(certificate)
 
 def delete_cert_record_and_resource(certificate, listener_arn, alb=alb, db=db):
     try:

--- a/tests/integration/alb/test_alb_remove_duplicate_certs.py
+++ b/tests/integration/alb/test_alb_remove_duplicate_certs.py
@@ -3,6 +3,7 @@ import pytest  # noqa F401
 from broker.models import Operation
 from tests.lib.factories import (
     CertificateFactory,
+    ChallengeFactory,
     ALBServiceInstanceFactory,
     OperationFactory,
 )
@@ -141,6 +142,9 @@ def test_delete_duplicate_cert_record_commit(no_context_app, no_context_clean_db
     certificate = CertificateFactory.create(
         service_instance=service_instance,
         iam_server_certificate_arn="arn1"
+    )
+    challenge = ChallengeFactory.create(
+        certificate_id = certificate.id
     )
     no_context_clean_db.session.commit()
 


### PR DESCRIPTION
...so run it on the Certificate object instead.

See: https://stackoverflow.com/questions/19243964/sqlalchemy-delete-doesnt-cascade

## Security considerations

None; see previous PR.