### PR TITLE
Update remove duplicate cert logic

### DIFF
--- a/broker/duplicate_certs.py
+++ b/broker/duplicate_certs.py
@@ -2,7 +2,7 @@ import logging
 
 from sqlalchemy import func, select, desc
 
-from broker.aws import alb
+from broker.aws import alb, iam_govcloud
 from broker.extensions import config, db
 from broker.models import ALBServiceInstance, Certificate
 
@@ -48,6 +48,15 @@ def delete_duplicate_cert_db_record(duplicate_cert):
     ).first()
     db.session.delete(certificate)
 
+def delete_iam_server_certificate(certificate_name):
+    try:
+        iam_govcloud.delete_server_certificate(
+            ServerCertificateName=certificate_name
+        )
+        logger.info(f"Deleted IAM certificate {certificate_name}")
+    except iam_govcloud.exceptions.NoSuchEntityException as e:
+        logger.info(f"IAM certificate {certificate_name} does not exist: {e}, continuing")
+
 def delete_cert_record_and_resource(certificate, listener_arn, alb=alb, db=db):
     try:
         delete_duplicate_cert_db_record(certificate)
@@ -58,6 +67,9 @@ def delete_cert_record_and_resource(certificate, listener_arn, alb=alb, db=db):
                 Certificates=[{"CertificateArn": certificate.iam_server_certificate_arn}]
             )
             logger.info(f"Removed certificate {certificate.iam_server_certificate_arn} from listener {listener_arn}")
+
+        if certificate.iam_server_certificate_name:
+            delete_iam_server_certificate(certificate.iam_server_certificate_name)
 
         # only commit deletion if previous operations were successful
         db.session.commit()

--- a/tests/integration/alb/test_alb_remove_duplicate_certs.py
+++ b/tests/integration/alb/test_alb_remove_duplicate_certs.py
@@ -193,6 +193,22 @@ def test_delete_cert_record_and_resource_success(no_context_clean_db, no_context
 
     assert len(Certificate.query.all()) == 0
 
+def test_delete_cert_no_listener(no_context_clean_db, no_context_app, alb):
+  with no_context_app.app_context():
+    service_instance = ALBServiceInstanceFactory.create(id="1234")
+    certificate = CertificateFactory.create(
+        service_instance=service_instance,
+        iam_server_certificate_arn="arn1"
+    )
+
+    no_context_clean_db.session.commit()
+
+    assert len(Certificate.query.all()) == 1
+
+    delete_cert_record_and_resource(certificate, None)
+
+    assert len(Certificate.query.all()) == 0
+
 def test_remove_duplicate_certs_with_active_operations(no_context_clean_db, no_context_app, alb):
   with no_context_app.app_context():
     service_instance = ALBServiceInstanceFactory.create(id="1234")

--- a/tests/integration/alb/test_alb_remove_duplicate_certs.py
+++ b/tests/integration/alb/test_alb_remove_duplicate_certs.py
@@ -1,5 +1,6 @@
 import pytest  # noqa F401
 
+from botocore.exceptions import ClientError
 from broker.models import Operation
 from tests.lib.factories import (
     CertificateFactory,
@@ -169,6 +170,14 @@ def test_delete_iam_server_certificate_no_certificate(iam_govcloud):
     )
 
     delete_iam_server_certificate("name1")
+
+def test_delete_iam_server_certificate_unexpected_error(iam_govcloud):
+    with pytest.raises(ClientError):
+      iam_govcloud.expects_delete_server_certificate_returning_unexpected_error(
+          "name1"
+      )
+
+      delete_iam_server_certificate("name1")
 
 def test_delete_cert_record_and_resource_handle_exception(no_context_clean_db, no_context_app):
   with no_context_app.app_context():

--- a/tests/lib/fake_iam.py
+++ b/tests/lib/fake_iam.py
@@ -63,6 +63,15 @@ class FakeIAM(FakeAWS):
             expected_params={"ServerCertificateName": name},
         )
 
+    def expects_delete_server_certificate_returning_unexpected_error(self, name: str):
+        self.stubber.add_client_error(
+            "delete_server_certificate",
+            service_error_code="UnexpectedError",
+            service_message="Unexpected error",
+            http_status_code=500,
+            expected_params={"ServerCertificateName": name},
+        )
+
 
 @pytest.fixture(autouse=True)
 def iam_commercial():


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add logic to delete IAM server certificates
- Update logic to handle case of certificate with no listener ARN

## Security considerations

None
