### PR TITLE
Update metric name and certificate removal logic

### DIFF
--- a/broker/duplicate_certs.py
+++ b/broker/duplicate_certs.py
@@ -64,15 +64,20 @@ def get_listener_cert_arns(listener_arn, alb=alb):
     listener_cert_arns = [cert["CertificateArn"] for cert in response["Certificates"]]
     return listener_cert_arns
 
-def remove_certificate_from_listener_and_wait_for_deletion(listener_arn, certificate_arn):
+def remove_certificate_from_listener_and_verify_removal(listener_arn, certificate_arn, alb=alb):
     alb.remove_listener_certificates(
         ListenerArn=listener_arn,
         Certificates=[{"CertificateArn": certificate_arn}]
     )
+    attempts = 0
     while True:
-        listener_cert_arns = get_listener_cert_arns(listener_arn)
+        if (attempts == 10):
+            logger.info(f"Could not verify certificate {certificate_arn} was removed from listener {listener_arn} after 10 tries, giving up")
+            break
+        listener_cert_arns = get_listener_cert_arns(listener_arn, alb=alb)
         if certificate_arn not in listener_cert_arns:
             break
+        attempts += 1
     logger.info(f"Removed certificate {certificate_arn} from listener {listener_arn}")
 
 def delete_cert_record_and_resource(certificate, listener_arn, alb=alb, db=db):
@@ -80,7 +85,7 @@ def delete_cert_record_and_resource(certificate, listener_arn, alb=alb, db=db):
         delete_duplicate_cert_db_record(certificate)
         
         if listener_arn:
-            remove_certificate_from_listener_and_wait_for_deletion(listener_arn, certificate.iam_server_certificate_arn)
+            remove_certificate_from_listener_and_verify_removal(listener_arn, certificate.iam_server_certificate_arn)
 
         if certificate.iam_server_certificate_name:
             delete_iam_server_certificate(certificate.iam_server_certificate_name)

--- a/broker/duplicate_certs.py
+++ b/broker/duplicate_certs.py
@@ -69,16 +69,12 @@ def remove_certificate_from_listener_and_verify_removal(listener_arn, certificat
         ListenerArn=listener_arn,
         Certificates=[{"CertificateArn": certificate_arn}]
     )
-    attempts = 0
-    while True:
-        if (attempts == 10):
-            logger.info(f"Could not verify certificate {certificate_arn} was removed from listener {listener_arn} after 10 tries, giving up")
-            break
+    for _ in range(10):
         listener_cert_arns = get_listener_cert_arns(listener_arn, alb=alb)
         if certificate_arn not in listener_cert_arns:
-            break
-        attempts += 1
-    logger.info(f"Removed certificate {certificate_arn} from listener {listener_arn}")
+            logger.info(f"Removed certificate {certificate_arn} from listener {listener_arn}")
+            return
+    logger.info(f"Could not verify certificate {certificate_arn} was removed from listener {listener_arn} after 10 tries, giving up")
 
 def delete_cert_record_and_resource(certificate, listener_arn, alb=alb, db=db):
     try:

--- a/broker/duplicate_certs.py
+++ b/broker/duplicate_certs.py
@@ -69,12 +69,13 @@ def remove_certificate_from_listener_and_verify_removal(listener_arn, certificat
         ListenerArn=listener_arn,
         Certificates=[{"CertificateArn": certificate_arn}]
     )
-    for _ in range(10):
+    max_attempts = 10
+    for _ in range(max_attempts):
         listener_cert_arns = get_listener_cert_arns(listener_arn, alb=alb)
         if certificate_arn not in listener_cert_arns:
             logger.info(f"Removed certificate {certificate_arn} from listener {listener_arn}")
             return
-    logger.info(f"Could not verify certificate {certificate_arn} was removed from listener {listener_arn} after 10 tries, giving up")
+    logger.info(f"Could not verify certificate {certificate_arn} was removed from listener {listener_arn} after {max_attempts} tries, giving up")
 
 def delete_cert_record_and_resource(certificate, listener_arn, alb=alb, db=db):
     try:

--- a/broker/duplicate_certs.py
+++ b/broker/duplicate_certs.py
@@ -40,7 +40,7 @@ def get_duplicate_certs_for_service(service_instance_id):
 def log_duplicate_alb_cert_metrics(logger=logger):
   for duplicate_result in find_duplicate_alb_certs():
     [service_instance_id, num_duplicates] = duplicate_result
-    logger.info(f"service_instance_cert_count{{service_instance_id=\"{service_instance_id}\"}} {num_duplicates}")
+    logger.info(f"service_instance_duplicate_cert_count{{service_instance_id=\"{service_instance_id}\"}} {num_duplicates}")
 
 def delete_duplicate_cert_db_record(duplicate_cert):
     certificate = Certificate.query.filter(

--- a/tests/integration/alb/test_alb_check_duplicate_certs.py
+++ b/tests/integration/alb/test_alb_check_duplicate_certs.py
@@ -85,5 +85,5 @@ def test_duplicate_alb_certs_output(no_context_clean_db, no_context_app):
 
     log_duplicate_alb_cert_metrics(logger=fakeLogger)
 
-    assert fakeLogger.output.strip() == "service_instance_cert_count{service_instance_id=\"1234\"} 2"
+    assert fakeLogger.output.strip() == "service_instance_duplicate_cert_count{service_instance_id=\"1234\"} 2"
 

--- a/tests/integration/alb/test_alb_remove_duplicate_certs.py
+++ b/tests/integration/alb/test_alb_remove_duplicate_certs.py
@@ -117,6 +117,7 @@ def test_delete_cert_record_success(no_context_app, no_context_clean_db, alb):
     assert len(Certificate.query.all()) == 1
 
     alb.expect_remove_certificate_from_listener("1234", "arn1")
+    alb.expect_get_certificates_for_listener(service_instance.id)
 
     delete_cert_record_and_resource(certificate, "1234")
 
@@ -214,6 +215,7 @@ def test_delete_cert_record_and_resource_success(no_context_clean_db, no_context
     assert len(Certificate.query.all()) == 1
 
     alb.expect_remove_certificate_from_listener(service_instance.id, "arn1")
+    alb.expect_get_certificates_for_listener(service_instance.id)
     iam_govcloud.expects_delete_server_certificate(
         "name1"
     )
@@ -251,6 +253,7 @@ def test_delete_cert_record_and_resource_no_certificate(no_context_clean_db, no_
     assert len(Certificate.query.all()) == 1
 
     alb.expect_remove_certificate_from_listener(service_instance.id, "arn1")
+    alb.expect_get_certificates_for_listener(service_instance.id)
     iam_govcloud.expects_delete_server_certificate_returning_no_such_entity(
         "name1"
     )
@@ -309,13 +312,16 @@ def test_remove_duplicate_certs_for_service(no_context_clean_db, no_context_app,
     }, {
       "CertificateArn": "arn3"
     }])
-    alb.expect_remove_certificate_from_listener(service_instance.id, "arn2")
-    alb.expect_remove_certificate_from_listener(service_instance.id, "arn3")
 
     no_context_clean_db.session.commit()
 
     results = get_duplicate_certs_for_service(service_instance.id)
     assert len(results) == 2
+
+    alb.expect_remove_certificate_from_listener(service_instance.id, "arn2")
+    alb.expect_get_certificates_for_listener(service_instance.id)
+    alb.expect_remove_certificate_from_listener(service_instance.id, "arn3")
+    alb.expect_get_certificates_for_listener(service_instance.id)
     
     remove_duplicate_alb_certs(listener_arns=[service_instance.id])
     

--- a/tests/lib/fake_alb.py
+++ b/tests/lib/fake_alb.py
@@ -40,7 +40,7 @@ class FakeALB(FakeAWS):
         )
 
     def expect_get_certificates_for_listener(self, listener_arn, num_certificates=0, certificates=[]):
-        if len(certificates) == 0:
+        if len(certificates) == 0 and num_certificates > 0:
             certificates = [{"CertificateArn": f"{listener_arn}/certificate-arn", "IsDefault": True}]
             for i in range(num_certificates):
                 certificates.append(


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update metric name for duplicate certs to `service_instance_duplicate_cert_count` to clarify that it is a count of duplicate certificates for a service, not all certificates for a service. There should be a total of `service_instance_duplicate_cert_count` + 1 (current certificate) certificates for a service
- Update logic for removing certificates from load balancer listeners to wait for the certificate to no longer be listed in the certificates for that listener. This fixes a bug I observed in the removal where attempting to delete the certificate itself immediately after removing it from the listener failed because the removal from the listener hadn't fully propagated through AWS

## Security considerations

None
