### PR TITLE
fix ci script to look for correct metric

### DIFF
--- a/ci/check-duplicate-certs.sh
+++ b/ci/check-duplicate-certs.sh
@@ -35,7 +35,7 @@ while [[ "$status" == 'RUNNING' ]]; do
 done
 
 DUPLICATE_CERTS_OUTPUT=$(mktemp)
-cf logs "$APP_NAME" --recent | grep 'service_instance_cert_count' | awk '{print $4 " " $5}' > "$DUPLICATE_CERTS_OUTPUT"
+cf logs "$APP_NAME" --recent | grep 'service_instance_duplicate_cert_count' | awk '{print $4 " " $5}' > "$DUPLICATE_CERTS_OUTPUT"
 cat "$DUPLICATE_CERTS_OUTPUT"
 curl --data-binary @- "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/domain_broker/instance/${ENVIRONMENT}" < "$DUPLICATE_CERTS_OUTPUT"
 


### PR DESCRIPTION
## Changes proposed in this pull request:

The metric name for duplicate certs per service changed so we need to update the script that greps for that metric in the app output and pushes it to Prometheus

## Security considerations

None
