### PR TITLE
refactor update checks and logic

### DIFF
--- a/tests/integration/test_plan_changes.py
+++ b/tests/integration/test_plan_changes.py
@@ -55,11 +55,6 @@ def test_refuses_if_new_type_not_serviceinstance(cdn_instance):
         change_instance_type(cdn_instance, ServiceInstance, None)
 
 
-def test_refuses_if_not_serviceinstance():
-    with pytest.raises(NotImplementedError):
-        change_instance_type(Challenge(), ALBServiceInstance, None)
-
-
 def test_returns_instance_if_same_type(cdn_instance):
     instance = change_instance_type(cdn_instance, CDNServiceInstance, None)
     assert instance is cdn_instance


### PR DESCRIPTION
## Changes proposed in this pull request:

- simplify logic on service instance type changes


## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None - just refactoring