### PR TITLE
make tests run a little less slowly

### DIFF
--- a/dev
+++ b/dev
@@ -73,10 +73,13 @@ build_image() {
 }
 
 run_docker() {
+  # the unnamed volume at `/app/venv/` is just to shadow the local
+  # virtual environment. This is a silly hack so ptw will be a bit faster
   docker run \
     --rm \
     -it \
     -v "$PWD:/app" \
+    -v "/app/venv/" \
     "${built_image_name}" \
     "$*"
 }

--- a/docker/tests
+++ b/docker/tests
@@ -9,7 +9,7 @@ export FLASK_ENV=test
 
 if [[ "$#" -ge 1 ]] && [[ "$1" == "watch" ]]; then
   shift
-  ptw . --now --clear --delay 0.2 -- -Werror -vv "$@"
+  ptw .
 else
   python -m pytest -Werror -vv "$@"
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,12 @@ exclude = '''
   | dist
 )
 '''
+
+[tool.pytest-watcher]
+now = true
+clear = true
+delay = 0.2
+runner = "pytest"
+runner_args = ["-Werror", "-vv"]
+patterns = ["broker/*.py", "tests/*.py"]
+ignore_patterns = ["venv/*", ".venv/*"]


### PR DESCRIPTION
## Changes proposed in this pull request:

- move ptw config to `pyproject.toml`
- avoid including the host virtualenv in the container mounts so ptw performs slightly better
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations
 None
