### PR TITLE
set plan visibility for dedicated plan

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -346,12 +346,12 @@ jobs:
         <<: *cf-manifest-vars
         <<: *cf-manifest-env-dev
   - task: register-broker
-    file: pipeline-tasks/register-service-broker.yml
+    file: pipeline-tasks/register-service-broker-and-set-plan-visibility.yml
     params:
       <<: *cf-creds-dev
       <<: *broker-register-params
-  - task: register-broker-dedicated
-    file: pipeline-tasks/register-service-broker.yml
+  - task: set-plan-visibility-dedicated
+    file: pipeline-tasks/set-plan-visibility.yml
     params:
       <<: *cf-creds-dev
       <<: *broker-register-params-dedicated
@@ -422,12 +422,12 @@ jobs:
         <<: *cf-manifest-vars
         <<: *cf-manifest-env-staging
   - task: register-broker
-    file: pipeline-tasks/register-service-broker.yml
+    file: pipeline-tasks/register-service-broker-and-set-plan-visibility.yml
     params:
       <<: *cf-creds-staging
       <<: *broker-register-params
-  - task: register-broker-dedicated
-    file: pipeline-tasks/register-service-broker.yml
+  - task: set-plan-visibility-dedicated
+    file: pipeline-tasks/set-plan-visibility.yml
     params:
       <<: *cf-creds-staging
       <<: *broker-register-params-dedicated
@@ -559,12 +559,12 @@ jobs:
         <<: *cf-manifest-vars
         <<: *cf-manifest-env-production
   - task: register-broker
-    file: pipeline-tasks/register-service-broker.yml
+    file: pipeline-tasks/register-service-broker-and-set-plan-visibility.yml
     params:
       <<: *cf-creds-production
       <<: *broker-register-params
-  - task: register-broker-dedicated
-    file: pipeline-tasks/register-service-broker.yml
+  - task: set-plan-visibility-dedicated
+    file: pipeline-tasks/set-plan-visibility.yml
     params:
       <<: *cf-creds-staging
       <<: *broker-register-params-dedicated


### PR DESCRIPTION
## Changes proposed in this pull request:

- set plan visibility for dedicated plan


## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

[Note the any security considerations here, or make note of why there are none]
