### PR TITLE
set token back to the thing I already set it to ?

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -354,7 +354,7 @@ jobs:
     file: pipeline-tasks/register-service-broker.yml
     params:
       <<: *cf-creds-dev
-      <<: *broker-register-params-dedicated
+      <<: *dedicated-plan-visibility-params
       # space-separated list of org names that should have the dedicated alb plan
       SERVICE_ORGANIZATION: ((dev-dedicated-alb-org-names))
   on_failure:
@@ -430,7 +430,7 @@ jobs:
     file: pipeline-tasks/register-service-broker.yml
     params:
       <<: *cf-creds-staging
-      <<: *broker-register-params-dedicated
+      <<: *dedicated-plan-visibility-params
       # space-separated list of org names that should have the dedicated alb plan
       SERVICE_ORGANIZATION: ((staging-dedicated-alb-org-names))
   on_failure:
@@ -567,7 +567,7 @@ jobs:
     file: pipeline-tasks/register-service-broker.yml
     params:
       <<: *cf-creds-staging
-      <<: *broker-register-params-dedicated
+      <<: *dedicated-plan-visibility-params
       # space-separated list of org names that should have the dedicated alb plan
       SERVICE_ORGANIZATION: ((production-dedicated-alb-org-names))
   on_failure:


### PR DESCRIPTION
## Changes proposed in this pull request:

- set token back to the thing I already set it to ?


## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None