### PR TITLE
use new task file name to test if symlinks are broken

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -346,12 +346,12 @@ jobs:
         <<: *cf-manifest-vars
         <<: *cf-manifest-env-dev
   - task: register-broker
-    file: pipeline-tasks/register-service-broker.yml
+    file: pipeline-tasks/register-service-broker-and-set-plan-visibility.yml
     params:
       <<: *cf-creds-dev
       <<: *broker-register-params
   - task: register-broker-dedicated
-    file: pipeline-tasks/register-service-broker.yml
+    file: pipeline-tasks/register-service-broker-and-set-plan-visibility.yml
     params:
       <<: *cf-creds-dev
       <<: *dedicated-plan-visibility-params
@@ -422,12 +422,12 @@ jobs:
         <<: *cf-manifest-vars
         <<: *cf-manifest-env-staging
   - task: register-broker
-    file: pipeline-tasks/register-service-broker.yml
+    file: pipeline-tasks/register-service-broker-and-set-plan-visibility.yml
     params:
       <<: *cf-creds-staging
       <<: *broker-register-params
   - task: register-broker-dedicated
-    file: pipeline-tasks/register-service-broker.yml
+    file: pipeline-tasks/register-service-broker-and-set-plan-visibility.yml
     params:
       <<: *cf-creds-staging
       <<: *dedicated-plan-visibility-params
@@ -559,12 +559,12 @@ jobs:
         <<: *cf-manifest-vars
         <<: *cf-manifest-env-production
   - task: register-broker
-    file: pipeline-tasks/register-service-broker.yml
+    file: pipeline-tasks/register-service-broker-and-set-plan-visibility.yml
     params:
       <<: *cf-creds-production
       <<: *broker-register-params
   - task: register-broker-dedicated
-    file: pipeline-tasks/register-service-broker.yml
+    file: pipeline-tasks/register-service-broker-and-set-plan-visibility.yml
     params:
       <<: *cf-creds-staging
       <<: *dedicated-plan-visibility-params


### PR DESCRIPTION
## Changes proposed in this pull request:

- use new task file name to test if symlinks are broken. The symlink _seemed_ to work once, but now concourse is complaining the file looks wrong
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None