### PR TITLE
Remove pins and ignore deprecation warning

### DIFF
--- a/docker/tests
+++ b/docker/tests
@@ -11,7 +11,7 @@ if [[ "$#" -ge 1 ]] && [[ "$1" == "watch" ]]; then
   shift
   ptw .
 else
-  python -m pytest -Werror -vv "$@"
+  python -m pytest -vv "$@"
 fi
 
 ./docker/stop-servers.sh

--- a/pip-tools/dev-requirements.txt
+++ b/pip-tools/dev-requirements.txt
@@ -4,7 +4,7 @@
 #
 #    ./dev update-requirements
 #
-acme==1.32.0
+acme==2.10.0
     # via -r pip-tools/../requirements.txt
 alembic==1.13.1
     # via
@@ -16,14 +16,14 @@ blinker==1.7.0
     # via
     #   -r pip-tools/../requirements.txt
     #   flask
-boto3==1.34.70
+boto3==1.34.77
     # via -r pip-tools/../requirements.txt
-botocore==1.34.70
+botocore==1.34.77
     # via
     #   -r pip-tools/../requirements.txt
     #   boto3
     #   s3transfer
-build==1.1.1
+build==1.2.1
     # via pip-tools
 certifi==2024.2.2
     # via
@@ -45,7 +45,7 @@ click==8.1.7
     #   black
     #   flask
     #   pip-tools
-cryptography==41.0.7
+cryptography==42.0.5
     # via
     #   -r pip-tools/../requirements.txt
     #   acme
@@ -174,13 +174,13 @@ psycopg2==2.9.9
     # via -r pip-tools/../requirements.txt
 pycodestyle==2.11.1
     # via flake8
-pycparser==2.21
+pycparser==2.22
     # via
     #   -r pip-tools/../requirements.txt
     #   cffi
 pyflakes==3.2.0
     # via flake8
-pyopenssl==23.2.0
+pyopenssl==24.1.0
     # via
     #   -r pip-tools/../requirements.txt
     #   acme
@@ -199,7 +199,7 @@ pytest==8.1.1
     #   pytest-profiling
 pytest-profiling==1.7.0
     # via -r pip-tools/dev-requirements.in
-pytest-watcher==0.4.1
+pytest-watcher==0.4.2
     # via -r pip-tools/dev-requirements.in
 python-dateutil==2.9.0.post0
     # via
@@ -227,11 +227,6 @@ requests==2.31.0
     # via
     #   -r pip-tools/../requirements.txt
     #   -r pip-tools/dev-requirements.in
-    #   acme
-    #   requests-toolbelt
-requests-toolbelt==1.0.0
-    # via
-    #   -r pip-tools/../requirements.txt
     #   acme
 rope==1.13.0
     # via -r pip-tools/dev-requirements.in
@@ -273,7 +268,7 @@ urllib3==2.2.1
     #   requests
 watchdog==4.0.0
     # via pytest-watcher
-werkzeug==3.0.1
+werkzeug==3.0.2
     # via
     #   -r pip-tools/../requirements.txt
     #   flask

--- a/pip-tools/requirements.in
+++ b/pip-tools/requirements.in
@@ -2,15 +2,11 @@ Flask-Migrate
 Flask-SQLAlchemy>3
 flask
 sqlalchemy
-# pin acme/pyopenssl until https://github.com/certbot/certbot/issues/9828 is fixed
-acme<2
-pyopenssl<23.3.0
+acme
 boto3
 cfenv
-cryptography>=3.3.2
 dnspython
 environs
-jinja2>=2.11.3
 openbrokerapi
 gunicorn
 huey

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,9 @@ runner = "pytest"
 runner_args = ["-Werror", "-vv"]
 patterns = ["broker/*.py", "tests/*.py"]
 ignore_patterns = ["venv/*", ".venv/*"]
+
+[tool.pytest.ini_options]
+filterwarnings = [
+  'error',
+  'ignore:X509Extension support in pyOpenSSL is deprecated. You should use the APIs in cryptography.:DeprecationWarning'
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,15 +4,15 @@
 #
 #    ./dev update-requirements
 #
-acme==1.32.0
+acme==2.10.0
     # via -r pip-tools/requirements.in
 alembic==1.13.1
     # via flask-migrate
 blinker==1.7.0
     # via flask
-boto3==1.34.70
+boto3==1.34.77
     # via -r pip-tools/requirements.in
-botocore==1.34.70
+botocore==1.34.77
     # via
     #   boto3
     #   s3transfer
@@ -26,9 +26,8 @@ charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via flask
-cryptography==41.0.7
+cryptography==42.0.5
     # via
-    #   -r pip-tools/requirements.in
     #   acme
     #   josepy
     #   pyopenssl
@@ -61,9 +60,7 @@ idna==3.6
 itsdangerous==2.1.2
     # via flask
 jinja2==3.1.3
-    # via
-    #   -r pip-tools/requirements.in
-    #   flask
+    # via flask
 jmespath==1.0.1
     # via
     #   boto3
@@ -89,11 +86,10 @@ packaging==24.0
     #   marshmallow
 psycopg2==2.9.9
     # via -r pip-tools/requirements.in
-pycparser==2.21
+pycparser==2.22
     # via cffi
-pyopenssl==23.2.0
+pyopenssl==24.1.0
     # via
-    #   -r pip-tools/requirements.in
     #   acme
     #   josepy
 pyrfc3339==1.1
@@ -109,10 +105,6 @@ pytz==2024.1
 redis==5.0.3
     # via -r pip-tools/requirements.in
 requests==2.31.0
-    # via
-    #   acme
-    #   requests-toolbelt
-requests-toolbelt==1.0.0
     # via acme
 s3transfer==0.10.1
     # via boto3
@@ -139,7 +131,7 @@ urllib3==2.2.1
     # via
     #   botocore
     #   requests
-werkzeug==3.0.1
+werkzeug==3.0.2
     # via flask
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION

## Changes proposed in this pull request:

- remove pins on some acme, pyopenssl, and cryptography to get latest versions
- add pytest config to suppress deprecation warning (this is what the upstream does, too)


## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

This lets us bump some versions with known security issues