### PR TITLE
make sure we call load_albs at least once during startup

### DIFF
--- a/broker/config.py
+++ b/broker/config.py
@@ -242,6 +242,7 @@ class TestConfig(DockerConfig):
         # if you need to see what sqlalchemy is doing
         # self.SQLALCHEMY_ECHO = True
         self.IAM_CERTIFICATE_PROPAGATION_TIME = 0
+        self.DEDICATED_ALB_LISTENER_ARNS = []
 
 
 class MissingRedisError(RuntimeError):

--- a/broker/tasks/huey.py
+++ b/broker/tasks/huey.py
@@ -6,7 +6,7 @@ from huey import RedisHuey, signals
 
 from sap import cf_logging
 from broker.extensions import config, db
-from broker.models import Operation
+from broker.models import Operation, DedicatedALBListener
 from broker.smtp import send_failed_operation_alert
 
 logger = logging.getLogger(__name__)
@@ -46,6 +46,7 @@ def create_app():
     app.config.from_object(config)
     huey.flask_app = app
     db.init_app(app)
+    DedicatedALBListener.load_albs(config.DEDICATED_ALB_LISTENER_ARNS)
 
 
 @huey.on_startup()

--- a/tests/integration/test_server_setup.py
+++ b/tests/integration/test_server_setup.py
@@ -1,7 +1,6 @@
 import pytest
 
 from broker.models import DedicatedALBListener
-from broker.tasks.alb import load_albs
 
 
 def test_server_runs(client):
@@ -13,7 +12,7 @@ def test_server_runs(client):
 def test_load_albs_on_startup(clean_db):
     listeners = DedicatedALBListener.query.all()
     assert len(listeners) == 0
-    load_albs(["arn-1", "arn-2", "arn-3"])
+    DedicatedALBListener.load_albs(["arn-1", "arn-2", "arn-3"])
     listeners = DedicatedALBListener.query.all()
     assert len(listeners) == 3
 
@@ -21,7 +20,7 @@ def test_load_albs_on_startup(clean_db):
 def test_load_albs_on_startup_doesnt_modify_assigned_instances(clean_db):
     listeners = DedicatedALBListener.query.all()
     assert len(listeners) == 0
-    load_albs(["arn-1", "arn-2"])
+    DedicatedALBListener.load_albs(["arn-1", "arn-2"])
     listeners = DedicatedALBListener.query.all()
     assert len(listeners) == 2
     dedicated_listener = DedicatedALBListener.query.filter(
@@ -32,7 +31,7 @@ def test_load_albs_on_startup_doesnt_modify_assigned_instances(clean_db):
     clean_db.session.commit()
     clean_db.session.expunge_all()
 
-    load_albs(["arn-1", "arn-2", "arn-3"])
+    DedicatedALBListener.load_albs(["arn-1", "arn-2", "arn-3"])
     listeners = DedicatedALBListener.query.all()
     assert len(listeners) == 3
     dedicated_listener = DedicatedALBListener.query.filter(


### PR DESCRIPTION
## Changes proposed in this pull request:

- make sure we call load_albs at least once during startup


## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None