### PR TITLE
separate tasks and feed context to load_alb task

### DIFF
--- a/broker/tasks/huey.py
+++ b/broker/tasks/huey.py
@@ -40,16 +40,21 @@ retriable_task = huey.context_task(
 )
 
 
-@huey.on_startup()
+@huey.on_startup(name="get_flask")
 def create_app():
     app = Flask(__name__)
     app.config.from_object(config)
     huey.flask_app = app
     db.init_app(app)
-    DedicatedALBListener.load_albs(config.DEDICATED_ALB_LISTENER_ARNS)
 
 
-@huey.on_startup()
+@huey.on_startup(name="load_albs")
+def load_albs():
+    with huey.flask_app.app_context():
+        DedicatedALBListener.load_albs(config.DEDICATED_ALB_LISTENER_ARNS)
+
+
+@huey.on_startup(name="logging")
 def initialize_logging():
     cf_logging.init()
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- separate tasks 
- feed context to load_alb task

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
