### PR TITLE
try loading albs at api startup instead

### DIFF
--- a/broker/app.py
+++ b/broker/app.py
@@ -29,6 +29,7 @@ def create_app():
 
     db.init_app(app)
     migrate.init_app(app, db)
+    models.DedicatedALBListener.load_albs(config.DEDICATED_ALB_LISTENER_ARNS)
 
     credentials = openbrokerapi.BrokerCredentials(
         app.config["BROKER_USERNAME"], app.config["BROKER_PASSWORD"]


### PR DESCRIPTION
## Changes proposed in this pull request:

- try loading albs at api startup instead


## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None