### PR TITLE
Load albs in a cron task

### DIFF
--- a/broker/app.py
+++ b/broker/app.py
@@ -29,7 +29,6 @@ def create_app():
 
     db.init_app(app)
     migrate.init_app(app, db)
-    models.DedicatedALBListener.load_albs(config.DEDICATED_ALB_LISTENER_ARNS)
 
     credentials = openbrokerapi.BrokerCredentials(
         app.config["BROKER_USERNAME"], app.config["BROKER_PASSWORD"]

--- a/broker/tasks/huey.py
+++ b/broker/tasks/huey.py
@@ -6,7 +6,7 @@ from huey import RedisHuey, signals
 
 from sap import cf_logging
 from broker.extensions import config, db
-from broker.models import Operation, DedicatedALBListener
+from broker.models import Operation
 from broker.smtp import send_failed_operation_alert
 
 logger = logging.getLogger(__name__)
@@ -46,12 +46,6 @@ def create_app():
     app.config.from_object(config)
     huey.flask_app = app
     db.init_app(app)
-
-
-@huey.on_startup(name="load_albs")
-def load_albs():
-    with huey.flask_app.app_context():
-        DedicatedALBListener.load_albs(config.DEDICATED_ALB_LISTENER_ARNS)
 
 
 @huey.on_startup(name="logging")


### PR DESCRIPTION
## Changes proposed in this pull request:

- Load albs in a cron task


## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None