### PR TITLE
add an explicit commit to alb save

### DIFF
--- a/broker/models.py
+++ b/broker/models.py
@@ -286,6 +286,7 @@ class DedicatedALBListener(Base):
             )
             stmt = stmt.on_conflict_do_nothing(index_elements=["listener_arn"])
             db.session.execute(stmt)
+            db.session.commit()
 
 
 def change_instance_type(


### PR DESCRIPTION
## Changes proposed in this pull request:

- add an explicit commit to alb save


## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None