### PR TITLE
fix watch-tests config, increase sleep time for ALB switches

### DIFF
--- a/broker/config.py
+++ b/broker/config.py
@@ -33,12 +33,20 @@ class Config:
         self.cfenv = AppEnv()
         self.FLASK_ENV = self.env("FLASK_ENV")
         self.TMPDIR = self.env("TMPDIR", "/app/tmp/")
-        self.DNS_PROPAGATION_SLEEP_TIME = self.env("DNS_PROPAGATION_SLEEP_TIME", "300")
+        # how long we wait for DNS before trying an acme challenge
+        self.DNS_PROPAGATION_SLEEP_TIME = self.env.int(
+            "DNS_PROPAGATION_SLEEP_TIME", 300
+        )
+        # how long we wait between updating DNS to point to a new ALB and removing the
+        # certificate from an old ALB
+        self.ALB_OVERLAP_SLEEP_TIME = self.env.int("ALB_OVERLAP_SLEEP_TIME", 900)
         self.CLOUDFRONT_PROPAGATION_SLEEP_TIME = 60  # Seconds
         self.SQLALCHEMY_TRACK_MODIFICATIONS = False
         self.TESTING = True
         self.DEBUG = True
-        self.ACME_POLL_TIMEOUT_IN_SECONDS = self.env("ACME_POLL_TIMEOUT_IN_SECONDS", 90)
+        self.ACME_POLL_TIMEOUT_IN_SECONDS = self.env.int(
+            "ACME_POLL_TIMEOUT_IN_SECONDS", 90
+        )
         self.AWS_POLL_WAIT_TIME_IN_SECONDS = 60
         self.AWS_POLL_MAX_ATTEMPTS = 10
         self.IGNORE_DUPLICATE_DOMAINS = self.env.bool("IGNORE_DUPLICATE_DOMAINS", False)
@@ -236,6 +244,7 @@ class TestConfig(DockerConfig):
     def __init__(self):
         super().__init__()
         self.DNS_PROPAGATION_SLEEP_TIME = 0
+        self.ALB_OVERLAP_SLEEP_TIME = 0
         self.CLOUDFRONT_PROPAGATION_SLEEP_TIME = 0
         self.ACME_POLL_TIMEOUT_IN_SECONDS = 10
         self.AWS_POLL_WAIT_TIME_IN_SECONDS = 1

--- a/broker/tasks/alb.py
+++ b/broker/tasks/alb.py
@@ -174,7 +174,7 @@ def remove_certificate_from_previous_alb(operation_id, **kwargs):
     db.session.commit()
 
     if service_instance.previous_alb_listener_arn is not None:
-        time.sleep(int(config.DNS_PROPAGATION_SLEEP_TIME))
+        time.sleep(config.ALB_OVERLAP_SLEEP_TIME)
         alb.remove_listener_certificates(
             ListenerArn=service_instance.previous_alb_listener_arn,
             Certificates=[
@@ -202,7 +202,7 @@ def remove_certificate_from_previous_alb_during_update_to_dedicated(
     db.session.commit()
 
     if service_instance.previous_alb_listener_arn is not None:
-        time.sleep(int(config.DNS_PROPAGATION_SLEEP_TIME))
+        time.sleep(config.ALB_OVERLAP_SLEEP_TIME)
         alb.remove_listener_certificates(
             ListenerArn=service_instance.previous_alb_listener_arn,
             Certificates=[

--- a/broker/tasks/letsencrypt.py
+++ b/broker/tasks/letsencrypt.py
@@ -207,7 +207,7 @@ def answer_challenges(operation_id: int, **kwargs):
     if not unanswered:
         return
 
-    time.sleep(int(config.DNS_PROPAGATION_SLEEP_TIME))
+    time.sleep(config.DNS_PROPAGATION_SLEEP_TIME)
 
     account_key = serialization.load_pem_private_key(
         acme_user.private_key_pem.encode(), password=None, backend=default_backend()

--- a/docker/tests
+++ b/docker/tests
@@ -11,7 +11,7 @@ if [[ "$#" -ge 1 ]] && [[ "$1" == "watch" ]]; then
   shift
   ptw .
 else
-  python -m pytest -vv "$@"
+  python -m pytest "$@"
 fi
 
 ./docker/stop-servers.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,12 @@ now = true
 clear = true
 delay = 0.2
 runner = "pytest"
-runner_args = ["-Werror", "-vv"]
+runner_args = []
 patterns = ["broker/*.py", "tests/*.py"]
 ignore_patterns = ["venv/*", ".venv/*"]
 
 [tool.pytest.ini_options]
+addopts = ["-vv"]
 filterwarnings = [
   'error',
   'ignore:X509Extension support in pyOpenSSL is deprecated. You should use the APIs in cryptography.:DeprecationWarning'


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix watch-tests config
- increase sleep time for ALB switches


## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None