### PR TITLE
Bb/better dedicated alb sourcing

### DIFF
--- a/broker/config.py
+++ b/broker/config.py
@@ -54,8 +54,8 @@ class Config:
         # https://docs.aws.amazon.com/Route53/latest/APIReference/API_AliasTarget.html
         self.CLOUDFRONT_HOSTED_ZONE_ID = "Z2FDTNDATAQYW2"
 
-        # the maximum from AWS is 20, and we alert when we have 18 on a given alb
-        self.MAX_CERTS_PER_ALB = 17
+        # the maximum from AWS is 25, and we alert when we have 20 on a given alb
+        self.MAX_CERTS_PER_ALB = 19
 
 
 class AppConfig(Config):

--- a/broker/config.py
+++ b/broker/config.py
@@ -54,6 +54,9 @@ class Config:
         # https://docs.aws.amazon.com/Route53/latest/APIReference/API_AliasTarget.html
         self.CLOUDFRONT_HOSTED_ZONE_ID = "Z2FDTNDATAQYW2"
 
+        # the maximum from AWS is 20, and we alert when we have 18 on a given alb
+        self.MAX_CERTS_PER_ALB = 17
+
 
 class AppConfig(Config):
     """Base class for apps running in Cloud Foundry"""

--- a/broker/tasks/alb.py
+++ b/broker/tasks/alb.py
@@ -53,7 +53,7 @@ def get_lowest_dedicated_alb(service_instance, db):
         .where(DedicatedALBListener.dedicated_org == service_instance.org_id)
         .where(DedicatedALBServiceInstance.deactivated_at == null())
         .group_by(DedicatedALBListener.id)
-        .having(func.count(DedicatedALBServiceInstance.id) < 17)
+        .having(func.count(DedicatedALBServiceInstance.id) < config.MAX_CERTS_PER_ALB)
     ).all()
 
     if potential_listener_ids:

--- a/broker/tasks/alb.py
+++ b/broker/tasks/alb.py
@@ -1,7 +1,7 @@
 import logging
 import time
 
-from sqlalchemy import and_
+from sqlalchemy import and_, select, func
 from sqlalchemy.orm.attributes import flag_modified
 
 
@@ -9,6 +9,7 @@ from broker.aws import alb
 from broker.extensions import config, db
 from broker.models import (
     DedicatedALBListener,
+    DedicatedALBServiceInstance,
     Certificate,
     Operation,
 )
@@ -17,7 +18,9 @@ from broker.tasks import huey
 logger = logging.getLogger(__name__)
 
 
-def get_lowest_used_alb(listener_arns):
+def get_lowest_used_alb(listener_arns) -> tuple[str, str]:
+    # given a list of listener arns, find the listener with the least certificates associated
+    # return a tuple of the load balancer arn, listener arn, and number of certificates on the load balancer
     https_listeners = []
     for listener_arn in listener_arns:
         certificates = alb.describe_listener_certificates(ListenerArn=listener_arn)
@@ -25,22 +28,42 @@ def get_lowest_used_alb(listener_arns):
             dict(listener_arn=listener_arn, certificates=certificates["Certificates"])
         )
     https_listeners.sort(key=lambda x: len(x["certificates"]))
-    selected_arn = https_listeners[0]["listener_arn"]
+    selected_listener = https_listeners[0]
+    selected_arn = selected_listener["listener_arn"]
     listener_data = alb.describe_listeners(ListenerArns=[selected_arn])
     listener_data = listener_data["Listeners"][0]
     return listener_data["LoadBalancerArn"], listener_data["ListenerArn"]
 
 
 def get_lowest_dedicated_alb(service_instance, db):
-    # TODO: handle grabbing the next available ALB when ours are full, or nearly so
-    potential_listeners = DedicatedALBListener.query.filter(
-        DedicatedALBListener.dedicated_org == service_instance.org_id
+    potential_listener_ids = db.session.execute(
+        select(
+            DedicatedALBListener.id,
+            func.count(DedicatedALBServiceInstance.id).label("count"),
+        )
+        .join_from(
+            DedicatedALBListener,
+            DedicatedALBServiceInstance,
+            DedicatedALBListener.listener_arn
+            == DedicatedALBServiceInstance.alb_listener_arn,
+            isouter=True,
+        )
+        .where(DedicatedALBListener.dedicated_org == service_instance.org_id)
+        .group_by(DedicatedALBListener.id)
+        .having(func.count(DedicatedALBServiceInstance.id) < 17)
     ).all()
-    if len(potential_listeners) == 0:
+
+    if potential_listener_ids:
+        potential_listeners = [
+            db.session.get(DedicatedALBListener, listener_id[0])
+            for listener_id in potential_listener_ids
+        ]
+    else:
         potential_listeners = DedicatedALBListener.query.filter(
             DedicatedALBListener.dedicated_org
             == None  # noqa E711 # == None is what sqlalchemy wants, despite flake8's complaints
         ).all()
+
     arns = [listener.listener_arn for listener in potential_listeners]
     arns.sort()  # this just makes testing easier
     alb_arn, alb_listener_arn = get_lowest_used_alb(arns)

--- a/tests/integration/dedicated_alb/test_dedicated_alb_pick_listener.py
+++ b/tests/integration/dedicated_alb/test_dedicated_alb_pick_listener.py
@@ -90,3 +90,44 @@ def test_selects_unassigned_alb(clean_db, alb, service_instance):
     assert service_instance.alb_arn.startswith("alb-our-arn-0")
     assert listener.dedicated_org == "our-org"
     assert listener.alb_arn.startswith("alb-our-arn-0")
+
+
+def test_adds_new_alb_when_assigned_is_near_full(clean_db, alb, service_instance):
+
+    our_listener_0 = DedicatedALBListener(
+        listener_arn="our-arn-0", dedicated_org="our-org"
+    )
+    available_listener_0 = DedicatedALBListener(listener_arn="available-arn-0")
+    other_listener_0 = DedicatedALBListener(
+        listener_arn="other-arn-0", dedicated_org="other-org"
+    )
+    other_listener_1 = DedicatedALBListener(
+        listener_arn="other-arn-1", dedicated_org="other-org"
+    )
+
+    clean_db.session.add_all(
+        [our_listener_0, available_listener_0, other_listener_0, other_listener_1]
+    )
+    clean_db.session.commit()
+    for i in range(17):
+        instance = factories.DedicatedALBServiceInstanceFactory.create(
+            domain_names=[f"random{i}.example.com"], alb_listener_arn="our-arn-0"
+        )
+        clean_db.session.add(instance)
+    clean_db.session.commit()
+
+    clean_db.session.expunge_all()
+    service_instance = clean_db.session.get(DedicatedALBServiceInstance, "4321")
+    alb.expect_get_certificates_for_listener("available-arn-0", 0)
+    alb.expect_get_listeners("available-arn-0")
+    get_lowest_dedicated_alb(service_instance, clean_db)
+    alb.assert_no_pending_responses()
+    clean_db.session.expunge_all()
+
+    listener = DedicatedALBListener.query.filter(
+        DedicatedALBListener.listener_arn == "available-arn-0"
+    ).first()
+    service_instance = clean_db.session.get(DedicatedALBServiceInstance, "4321")
+    assert service_instance.alb_arn.startswith("alb-available-arn-0")
+    assert listener.dedicated_org == "our-org"
+    assert listener.alb_arn.startswith("alb-available-arn-0")

--- a/tests/integration/dedicated_alb/test_dedicated_alb_pick_listener.py
+++ b/tests/integration/dedicated_alb/test_dedicated_alb_pick_listener.py
@@ -109,7 +109,7 @@ def test_adds_new_alb_when_assigned_is_near_full(clean_db, alb, service_instance
         [our_listener_0, available_listener_0, other_listener_0, other_listener_1]
     )
     clean_db.session.commit()
-    for i in range(17):
+    for i in range(19):
         instance = factories.DedicatedALBServiceInstanceFactory.create(
             domain_names=[f"random{i}.example.com"], alb_listener_arn="our-arn-0"
         )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -245,3 +245,10 @@ def test_config_sets_ignore_duplicates_false_by_default(env, monkeypatch, mocked
     config = config_from_env()
 
     assert config.IGNORE_DUPLICATE_DOMAINS
+
+
+@pytest.mark.parametrize("env", ["production", "staging", "development"])
+def test_config_provides_max_alb_uses(env, monkeypatch, mocked_env):
+    config = config_from_env()
+
+    assert isinstance(config.MAX_CERTS_PER_ALB, int)


### PR DESCRIPTION
## Changes proposed in this pull request:

- dedicate a new ALB to an org when too few slots are left on the existing ALB
- fix some comments
- use `sqlalchemy.null` instead of `None` so we can shake some `# noqa`s

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None