### PR TITLE
fix empty result set 

### DIFF
--- a/broker/tasks/alb.py
+++ b/broker/tasks/alb.py
@@ -60,9 +60,7 @@ def get_lowest_dedicated_alb(service_instance, db):
         .group_by(DedicatedALBListener.id)
         .having(func.count(instance_subquery.id) < config.MAX_CERTS_PER_ALB)
     )
-    print(query)
     potential_listener_ids = db.session.execute(query).all()
-    print(potential_listener_ids)
 
     if len(potential_listener_ids) > 0:
         potential_listeners = [


### PR DESCRIPTION


## Changes proposed in this pull request:

- fix empty result set condition when a dedicated alb has only deactivated service instances
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None