### PR TITLE
Improve logging format for exceptions

### DIFF
--- a/broker/app.py
+++ b/broker/app.py
@@ -1,5 +1,6 @@
 from http import HTTPStatus
 import logging
+import sys
 
 from flask import Flask
 from openbrokerapi import api as openbrokerapi
@@ -18,6 +19,7 @@ from broker.duplicate_certs import (
     log_duplicate_alb_cert_metrics,
     remove_duplicate_alb_certs,
 )
+from broker.errors import handle_exception
 
 
 def create_app():
@@ -26,6 +28,8 @@ def create_app():
     flask_logging.init(app)
     logger = logging.getLogger(__name__)
     app.config.from_object(config)
+
+    sys.excepthook = handle_exception
 
     db.init_app(app)
     migrate.init_app(app, db)

--- a/broker/config.py
+++ b/broker/config.py
@@ -200,6 +200,7 @@ class DockerConfig(Config):
         self.DNS_ROOT_DOMAIN = "domains.cloud.test"
         self.DATABASE_ENCRYPTION_KEY = "Local Dev Encrytpion Key"
         self.DEFAULT_CLOUDFRONT_ORIGIN = "cloud.local"
+        self.DEDICATED_ALB_LISTENER_ARNS = []
         self.CLOUDFRONT_IAM_SERVER_CERTIFICATE_PREFIX = (
             "/cloudfront/external-domains-test/"
         )

--- a/broker/errors.py
+++ b/broker/errors.py
@@ -1,0 +1,14 @@
+import logging
+import sys
+
+
+def handle_exception(exc_type, exc_value, exc_traceback):
+    """log exceptions explicitly, so they get json-ified"""
+    logger = logging.getLogger(__name__)
+    if issubclass(exc_type, KeyboardInterrupt):
+        sys.__excepthook__(exc_type, exc_value, exc_traceback)
+        return
+
+    logger.exception(
+        "Uncaught exception", exc_info=(exc_type, exc_value, exc_traceback)
+    )

--- a/broker/huey_consumer.py
+++ b/broker/huey_consumer.py
@@ -1,3 +1,8 @@
+from sap import cf_logging
+
+# we need to init the logging before we import anything else in order for it to work
+cf_logging.init()
+
 from broker.app import create_app  # noqa F401
 from broker.tasks.huey import huey  # noqa F401
 from broker.tasks import pipelines, cron  # noqa F401

--- a/broker/tasks/huey.py
+++ b/broker/tasks/huey.py
@@ -5,6 +5,7 @@ from redis import ConnectionPool, SSLConnection
 from huey import RedisHuey, signals
 
 from sap import cf_logging
+
 from broker.extensions import config, db
 from broker.models import Operation
 from broker.smtp import send_failed_operation_alert
@@ -46,11 +47,6 @@ def create_app():
     app.config.from_object(config)
     huey.flask_app = app
     db.init_app(app)
-
-
-@huey.on_startup(name="logging")
-def initialize_logging():
-    cf_logging.init()
 
 
 @huey.pre_execute(name="Set Correlation ID")


### PR DESCRIPTION
## Changes proposed in this pull request:

- catch more worker logs with cf_logging
- push stack traces into json logs, so the full stack is in one log entry

N.B. some stuff still escapes cf_logging with this change, but this gets most of the interesting stuff

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None