### PR TITLE
Improve duplicate cert detection to handle dedicated ALBs

### DIFF
--- a/broker/duplicate_certs.py
+++ b/broker/duplicate_certs.py
@@ -179,13 +179,15 @@ def remove_duplicate_alb_certs(
     logger=logger
 ):
     service_instance_models = [ALBServiceInstance, DedicatedALBServiceInstance]
-    
+
     for service_instance_model in service_instance_models:
         if service_instance_model == ALBServiceInstance:
             listener_arns = alb_listener_arns
         elif service_instance_model == DedicatedALBServiceInstance:
             listener_arns = dedicated_listener_arns
         else:
+            # It is not really possible for this condition to be reached, but adding belt/suspenders
+            # in case of later code refactoring
             raise Exception(f"Could not find listener ARNs for model {service_instance_model}")
 
         for duplicate_result in find_duplicate_alb_certs(service_instance_model):

--- a/broker/duplicate_certs.py
+++ b/broker/duplicate_certs.py
@@ -4,57 +4,56 @@ from sqlalchemy import func, select, desc
 
 from broker.aws import alb, iam_govcloud
 from broker.extensions import config, db
-from broker.models import ALBServiceInstance, Certificate
+from broker.models import ALBServiceInstance, DedicatedALBServiceInstance, Certificate
 
 logger = logging.getLogger(__name__)
 
 
-def find_duplicate_alb_certs():
+def find_duplicate_alb_certs(service_instance_model):
     query = (
-        select(ALBServiceInstance.id, func.count(Certificate.id).label("cert_count"))
+        select(service_instance_model.id, func.count(Certificate.id).label("cert_count"))
         .select_from(Certificate)
         .join(
-            ALBServiceInstance,
-            ALBServiceInstance.id == Certificate.service_instance_id,
+            service_instance_model,
+            service_instance_model.id == Certificate.service_instance_id,
         )
-        .where(ALBServiceInstance.current_certificate_id != Certificate.id)
-        .group_by(ALBServiceInstance.id)
+        .where(service_instance_model.current_certificate_id != Certificate.id)
+        .group_by(service_instance_model.id)
         .having(func.count(Certificate.id) > 0)
         .order_by(desc("cert_count"))
     )
     return db.session.execute(query).fetchall()
 
 
-def get_service_duplicate_alb_cert_count(service_instance_id):
+def get_service_duplicate_alb_cert_count(service_instance_id, service_instance_model):
     query = (
         select(
             Certificate.id,
         )
         .select_from(Certificate)
         .join(
-            ALBServiceInstance,
-            ALBServiceInstance.id == Certificate.service_instance_id,
+            service_instance_model,
+            service_instance_model.id == Certificate.service_instance_id,
         )
         .where(
-            (ALBServiceInstance.current_certificate_id != Certificate.id)
+            (service_instance_model.current_certificate_id != Certificate.id)
             & (Certificate.service_instance_id == service_instance_id)
         )
     )
     results = db.session.execute(query).fetchall()
     return len(results)
 
-
-def get_duplicate_certs_for_service(service_instance_id):
+def get_duplicate_certs_for_service(service_instance_id, service_instance_model):
     return (
         Certificate.query.join(
-            ALBServiceInstance,
-            ALBServiceInstance.id == Certificate.service_instance_id,
+            service_instance_model,
+            service_instance_model.id == Certificate.service_instance_id,
         )
         .filter(
             Certificate.service_instance_id == service_instance_id,
-            Certificate.id != ALBServiceInstance.current_certificate_id,
+            Certificate.id != service_instance_model.current_certificate_id,
         )
-        .where(ALBServiceInstance.current_certificate_id != Certificate.id)
+        .where(service_instance_model.current_certificate_id != Certificate.id)
         .all()
     )
 
@@ -65,18 +64,20 @@ def log_duplicate_cert_count_metric(service_instance_id, num_duplicates, logger=
     )
 
 
-def get_and_log_service_duplicate_alb_cert_metric(service_instance_id, logger=logger):
-    num_duplicates = get_service_duplicate_alb_cert_count(service_instance_id)
+def get_and_log_service_duplicate_alb_cert_metric(service_instance_id, service_instance_model, logger=logger):
+    num_duplicates = get_service_duplicate_alb_cert_count(service_instance_id, service_instance_model)
     # Log metric of remaining duplicate count so Prometheus is updated
     log_duplicate_cert_count_metric(service_instance_id, num_duplicates, logger=logger)
 
 
-def log_duplicate_alb_cert_metrics(logger=logger):
-    for duplicate_result in find_duplicate_alb_certs():
-        [service_instance_id, num_duplicates] = duplicate_result
-        log_duplicate_cert_count_metric(
-            service_instance_id, num_duplicates, logger=logger
-        )
+def log_duplicate_alb_cert_metrics(service_instance_model=ALBServiceInstance, logger=logger):
+    service_instance_models = [ALBServiceInstance, DedicatedALBServiceInstance]
+    for service_instance_model in service_instance_models:
+        for duplicate_result in find_duplicate_alb_certs(service_instance_model):
+            [service_instance_id, num_duplicates] = duplicate_result
+            log_duplicate_cert_count_metric(
+                service_instance_id, num_duplicates, logger=logger
+            )
 
 
 def delete_duplicate_cert_db_record(duplicate_cert):
@@ -121,7 +122,7 @@ def remove_certificate_from_listener_and_verify_removal(
     )
 
 
-def delete_cert_record_and_resource(certificate, listener_arn, alb=alb, db=db):
+def delete_cert_record_and_resource(certificate, listener_arn, db=db):
     try:
         delete_duplicate_cert_db_record(certificate)
 
@@ -166,38 +167,43 @@ def get_matching_alb_listener_arns_for_cert_arns(
     return matched_listeners_dict
 
 
-def remove_duplicate_alb_certs(listener_arns=config.ALB_LISTENER_ARNS, logger=logger):
-    for duplicate_result in find_duplicate_alb_certs():
-        [service_instance_id, num_duplicates] = duplicate_result
+def remove_duplicate_alb_certs(
+    listener_arns=config.ALB_LISTENER_ARNS,
+    logger=logger
+):
+    service_instance_models = [ALBServiceInstance, DedicatedALBServiceInstance]
+    for service_instance_model in service_instance_models:
+        for duplicate_result in find_duplicate_alb_certs(service_instance_model):
+            [service_instance_id, num_duplicates] = duplicate_result
 
-        service_instance = db.session.get(ALBServiceInstance, service_instance_id)
-        if service_instance.has_active_operations():
+            service_instance = db.session.get(service_instance_model, service_instance_id)
+            if service_instance.has_active_operations():
+                logger.info(
+                    f"Instance {service_instance_id} has an active operation in progress, so duplicate certificates cannot be removed. Try again in a few minutes."
+                )
+                continue
+
             logger.info(
-                f"Instance {service_instance_id} has an active operation in progress, so duplicate certificates cannot be removed. Try again in a few minutes."
+                f"Found {num_duplicates} duplicate certificates for service instance {service_instance_id}"
             )
-            continue
 
-        logger.info(
-            f"Found {num_duplicates} duplicate certificates for service instance {service_instance_id}"
-        )
+            duplicate_certs = get_duplicate_certs_for_service(service_instance_id, service_instance_model)
+            duplicate_cert_arns = [
+                cert.iam_server_certificate_arn for cert in duplicate_certs
+            ]
 
-        duplicate_certs = get_duplicate_certs_for_service(service_instance_id)
-        duplicate_cert_arns = [
-            cert.iam_server_certificate_arn for cert in duplicate_certs
-        ]
-
-        # Get dictionary for reverse lookup of listener ARN by certificate ARN
-        listener_arns_dict = get_matching_alb_listener_arns_for_cert_arns(
-            duplicate_cert_arns, listener_arns
-        )
-
-        for duplicate_cert in duplicate_certs:
-            listener_arn = listener_arns_dict.get(
-                duplicate_cert.iam_server_certificate_arn
+            # Get dictionary for reverse lookup of listener ARN by certificate ARN
+            listener_arns_dict = get_matching_alb_listener_arns_for_cert_arns(
+                duplicate_cert_arns, listener_arns
             )
-            delete_cert_record_and_resource(duplicate_cert, listener_arn)
 
-        # Get and log metric of remaining count of duplicates so Prometheus is updated
-        get_and_log_service_duplicate_alb_cert_metric(
-            service_instance_id, logger=logger
-        )
+            for duplicate_cert in duplicate_certs:
+                listener_arn = listener_arns_dict.get(
+                    duplicate_cert.iam_server_certificate_arn
+                )
+                delete_cert_record_and_resource(duplicate_cert, listener_arn)
+
+            # Get and log metric of remaining count of duplicates so Prometheus is updated
+            get_and_log_service_duplicate_alb_cert_metric(
+                service_instance_id, service_instance_model, logger=logger
+            )

--- a/broker/duplicate_certs.py
+++ b/broker/duplicate_certs.py
@@ -122,13 +122,19 @@ def remove_certificate_from_listener_and_verify_removal(
     )
 
 
-def delete_cert_record_and_resource(certificate, listener_arn, db=db):
+def delete_cert_record_and_resource(
+    certificate,
+    listener_arn,
+    alb=alb,
+    db=db,
+    logger=logger,
+):
     try:
         delete_duplicate_cert_db_record(certificate)
 
         if listener_arn:
             remove_certificate_from_listener_and_verify_removal(
-                listener_arn, certificate.iam_server_certificate_arn
+                listener_arn, certificate.iam_server_certificate_arn, alb=alb
             )
 
         if certificate.iam_server_certificate_name:
@@ -201,7 +207,7 @@ def remove_duplicate_alb_certs(
                 listener_arn = listener_arns_dict.get(
                     duplicate_cert.iam_server_certificate_arn
                 )
-                delete_cert_record_and_resource(duplicate_cert, listener_arn)
+                delete_cert_record_and_resource(duplicate_cert, listener_arn, logger=logger)
 
             # Get and log metric of remaining count of duplicates so Prometheus is updated
             get_and_log_service_duplicate_alb_cert_metric(

--- a/broker/duplicate_certs.py
+++ b/broker/duplicate_certs.py
@@ -174,11 +174,20 @@ def get_matching_alb_listener_arns_for_cert_arns(
 
 
 def remove_duplicate_alb_certs(
-    listener_arns=config.ALB_LISTENER_ARNS,
+    alb_listener_arns=[config.ALB_LISTENER_ARNS],
+    dedicated_listener_arns=[config.DEDICATED_ALB_LISTENER_ARNS],
     logger=logger
 ):
     service_instance_models = [ALBServiceInstance, DedicatedALBServiceInstance]
+    
     for service_instance_model in service_instance_models:
+        if service_instance_model == ALBServiceInstance:
+            listener_arns = alb_listener_arns
+        elif service_instance_model == DedicatedALBServiceInstance:
+            listener_arns = dedicated_listener_arns
+        else:
+            raise Exception(f"Could not find listener ARNs for model {service_instance_model}")
+
         for duplicate_result in find_duplicate_alb_certs(service_instance_model):
             [service_instance_id, num_duplicates] = duplicate_result
 

--- a/tests/integration/alb/test_alb_remove_duplicate_certs.py
+++ b/tests/integration/alb/test_alb_remove_duplicate_certs.py
@@ -300,7 +300,7 @@ def test_remove_duplicate_certs_with_active_operations(
         results = get_duplicate_certs_for_service(service_instance.id, ALBServiceInstance)
         assert len(results) == 1
 
-        remove_duplicate_alb_certs(listener_arns=[service_instance.id])
+        remove_duplicate_alb_certs(alb_listener_arns=[service_instance.id])
 
         # nothing should get deleted if there are active operations for a service instance
         results = get_duplicate_certs_for_service(service_instance.id, ALBServiceInstance)
@@ -340,7 +340,7 @@ def test_remove_duplicate_certs_for_service(no_context_clean_db, no_context_app,
         fakeLogger = FakeLogger()
 
         remove_duplicate_alb_certs(
-            listener_arns=[service_instance.id], logger=fakeLogger
+            alb_listener_arns=[service_instance.id], logger=fakeLogger
         )
 
         assert (

--- a/tests/integration/dedicated_alb/test_dedicated_alb_check_duplicate_certs.py
+++ b/tests/integration/dedicated_alb/test_dedicated_alb_check_duplicate_certs.py
@@ -2,10 +2,10 @@ import pytest  # noqa F401
 
 from tests.lib.factories import (
     CertificateFactory,
-    ALBServiceInstanceFactory,
+    DedicatedALBServiceInstanceFactory,
 )
 
-from broker.models import ALBServiceInstance
+from broker.models import DedicatedALBServiceInstance
 
 from broker.duplicate_certs import (
     find_duplicate_alb_certs,
@@ -17,21 +17,21 @@ from broker.duplicate_certs import (
 
 def test_no_duplicate_alb_certs(no_context_clean_db, no_context_app):
     with no_context_app.app_context():
-        service_instance = ALBServiceInstanceFactory.create(id="1234")
+        service_instance = DedicatedALBServiceInstanceFactory.create(id="1234")
         CertificateFactory.create(
             service_instance=service_instance,
         )
 
         no_context_clean_db.session.commit()
 
-        results = find_duplicate_alb_certs(ALBServiceInstance)
+        results = find_duplicate_alb_certs(DedicatedALBServiceInstance)
 
         assert len(results) == 0
 
 
 def test_non_current_duplicate_alb_cert(no_context_clean_db, no_context_app):
     with no_context_app.app_context():
-        service_instance = ALBServiceInstanceFactory.create(id="1234")
+        service_instance = DedicatedALBServiceInstanceFactory.create(id="1234")
         certificate = CertificateFactory.create(
             service_instance=service_instance,
         )
@@ -42,7 +42,7 @@ def test_non_current_duplicate_alb_cert(no_context_clean_db, no_context_app):
 
         no_context_clean_db.session.commit()
 
-        results = find_duplicate_alb_certs(ALBServiceInstance)
+        results = find_duplicate_alb_certs(DedicatedALBServiceInstance)
 
         assert len(results) == 1
         assert results == [("1234", 1)]
@@ -50,7 +50,7 @@ def test_non_current_duplicate_alb_cert(no_context_clean_db, no_context_app):
 
 def test_multiple_non_current_duplicate_alb_certs(no_context_clean_db, no_context_app):
     with no_context_app.app_context():
-        service_instance = ALBServiceInstanceFactory.create(id="1234")
+        service_instance = DedicatedALBServiceInstanceFactory.create(id="1234")
         certificate = CertificateFactory.create(
             service_instance=service_instance,
         )
@@ -64,7 +64,7 @@ def test_multiple_non_current_duplicate_alb_certs(no_context_clean_db, no_contex
 
         no_context_clean_db.session.commit()
 
-        results = find_duplicate_alb_certs(ALBServiceInstance)
+        results = find_duplicate_alb_certs(DedicatedALBServiceInstance)
 
         assert len(results) == 1
         assert results == [("1234", 2)]
@@ -72,19 +72,19 @@ def test_multiple_non_current_duplicate_alb_certs(no_context_clean_db, no_contex
 
 def test_no_service_duplicate_alb_certs(no_context_clean_db, no_context_app):
     with no_context_app.app_context():
-        service_instance = ALBServiceInstanceFactory.create(id="1234")
+        service_instance = DedicatedALBServiceInstanceFactory.create(id="1234")
         CertificateFactory.create(
             service_instance=service_instance,
         )
 
         no_context_clean_db.session.commit()
 
-        assert get_service_duplicate_alb_cert_count(service_instance.id, ALBServiceInstance) == 0
+        assert get_service_duplicate_alb_cert_count(service_instance.id, DedicatedALBServiceInstance) == 0
 
 
 def test_service_duplicate_alb_certs(no_context_clean_db, no_context_app):
     with no_context_app.app_context():
-        service_instance = ALBServiceInstanceFactory.create(id="1234")
+        service_instance = DedicatedALBServiceInstanceFactory.create(id="1234")
         certificate = CertificateFactory.create(
             service_instance=service_instance,
         )
@@ -95,12 +95,12 @@ def test_service_duplicate_alb_certs(no_context_clean_db, no_context_app):
 
         no_context_clean_db.session.commit()
 
-        assert get_service_duplicate_alb_cert_count(service_instance.id, ALBServiceInstance) == 1
+        assert get_service_duplicate_alb_cert_count(service_instance.id, DedicatedALBServiceInstance) == 1
 
 
 def test_service_duplicate_alb_certs_output(no_context_clean_db, no_context_app):
     with no_context_app.app_context():
-        service_instance = ALBServiceInstanceFactory.create(id="1234")
+        service_instance = DedicatedALBServiceInstanceFactory.create(id="1234")
         certificate = CertificateFactory.create(
             service_instance=service_instance,
         )
@@ -121,7 +121,7 @@ def test_service_duplicate_alb_certs_output(no_context_clean_db, no_context_app)
         fakeLogger = FakeLogger()
 
         get_and_log_service_duplicate_alb_cert_metric(
-            service_instance.id, ALBServiceInstance, logger=fakeLogger
+            service_instance.id, DedicatedALBServiceInstance, logger=fakeLogger
         )
 
         assert (
@@ -132,7 +132,7 @@ def test_service_duplicate_alb_certs_output(no_context_clean_db, no_context_app)
 
 def test_duplicate_alb_certs_output(no_context_clean_db, no_context_app):
     with no_context_app.app_context():
-        service_instance = ALBServiceInstanceFactory.create(id="1234")
+        service_instance = DedicatedALBServiceInstanceFactory.create(id="1234")
         certificate = CertificateFactory.create(
             service_instance=service_instance,
         )

--- a/tests/integration/dedicated_alb/test_dedicated_alb_remove_duplicate_certs.py
+++ b/tests/integration/dedicated_alb/test_dedicated_alb_remove_duplicate_certs.py
@@ -300,7 +300,7 @@ def test_remove_duplicate_certs_with_active_operations(
         results = get_duplicate_certs_for_service(service_instance.id, DedicatedALBServiceInstance)
         assert len(results) == 1
 
-        remove_duplicate_alb_certs(listener_arns=[service_instance.id])
+        remove_duplicate_alb_certs(dedicated_listener_arns=[service_instance.id])
 
         # nothing should get deleted if there are active operations for a service instance
         results = get_duplicate_certs_for_service(service_instance.id, DedicatedALBServiceInstance)
@@ -340,7 +340,7 @@ def test_remove_duplicate_certs_for_service(no_context_clean_db, no_context_app,
         fakeLogger = FakeLogger()
 
         remove_duplicate_alb_certs(
-            listener_arns=[service_instance.id], logger=fakeLogger
+          dedicated_listener_arns=[service_instance.id], logger=fakeLogger
         )
 
         assert (

--- a/tests/integration/dedicated_alb/test_dedicated_alb_remove_duplicate_certs.py
+++ b/tests/integration/dedicated_alb/test_dedicated_alb_remove_duplicate_certs.py
@@ -351,7 +351,6 @@ def test_remove_duplicate_certs_for_service(no_context_clean_db, no_context_app,
         results = get_duplicate_certs_for_service(service_instance.id, DedicatedALBServiceInstance)
         assert len(results) == 0
 
-
 def test_remove_certificate_from_listener_and_verify_removal_correctly_breaks():
     class FakeALBTest:
         def __init__(self):

--- a/tests/integration/dedicated_alb/test_dedicated_alb_remove_duplicate_certs.py
+++ b/tests/integration/dedicated_alb/test_dedicated_alb_remove_duplicate_certs.py
@@ -1,0 +1,374 @@
+import pytest  # noqa F401
+
+from botocore.exceptions import ClientError
+from broker.models import DedicatedALBServiceInstance, Operation
+from tests.lib.factories import (
+    CertificateFactory,
+    ChallengeFactory,
+    DedicatedALBServiceInstanceFactory,
+    OperationFactory,
+)
+
+from broker.duplicate_certs import (
+    get_duplicate_certs_for_service,
+    remove_duplicate_alb_certs,
+    get_matching_alb_listener_arns_for_cert_arns,
+    delete_duplicate_cert_db_record,
+    delete_cert_record_and_resource,
+    delete_iam_server_certificate,
+    remove_certificate_from_listener_and_verify_removal,
+)
+from broker.models import Certificate
+
+class FakeLogger:
+    def __init__(self):
+        self.output = []
+        self.error_output = []
+
+    def info(self, input):
+        self.output.append(input)
+
+    def error(self, input):
+        self.error_output.append(input)
+
+def test_get_duplicate_certs_for_service(no_context_clean_db, no_context_app):
+    with no_context_app.app_context():
+        service_instance = DedicatedALBServiceInstanceFactory.create(id="1234")
+        certificate1 = CertificateFactory.create(
+            service_instance=service_instance,
+        )
+        certificate2 = CertificateFactory.create(
+            service_instance=service_instance,
+        )
+        certificate3 = CertificateFactory.create(
+            service_instance=service_instance,
+        )
+        service_instance.current_certificate_id = certificate1.id
+
+        no_context_clean_db.session.commit()
+
+        results = get_duplicate_certs_for_service(service_instance.id, DedicatedALBServiceInstance)
+
+        assert len(results) == 2
+        assert results == [certificate2, certificate3]
+
+
+def test_get_matching_alb_listener_arns_for_single_cert_arn(alb):
+    alb.expect_get_certificates_for_listener("listener-arn-0", 1)
+    results = get_matching_alb_listener_arns_for_cert_arns(
+        ["listener-arn-0/certificate-arn"], ["listener-arn-0"]
+    )
+    assert results == {"listener-arn-0/certificate-arn": "listener-arn-0"}
+
+
+def test_get_matching_alb_listener_arns_breaks_correctly(alb):
+    class FakeALBTest:
+        def __init__(self):
+            self.requested_listener_arns = []
+
+        def describe_listener_certificates(self, ListenerArn=""):
+            self.requested_listener_arns.append(ListenerArn)
+            return {
+                "Certificates": [{"CertificateArn": "listener-arn-0/certificate-arn"}],
+            }
+
+    fakeAlbTester = FakeALBTest()
+    get_matching_alb_listener_arns_for_cert_arns(
+        ["listener-arn-0/certificate-arn"],
+        ["listener-arn-0", "listener-arn-1"],
+        alb=fakeAlbTester,
+    )
+    # Only request for the first listener was made because it
+    # contained all of the specified certificate ARNs
+    assert fakeAlbTester.requested_listener_arns == ["listener-arn-0"]
+
+
+def test_get_matching_alb_listener_arns_for_multiple_cert_arns(alb):
+    alb.expect_get_certificates_for_listener("listener-arn-0", 1)
+    results = get_matching_alb_listener_arns_for_cert_arns(
+        ["listener-arn-0/certificate-arn", "listener-arn-0/certificate-arn-0"],
+        ["listener-arn-0"],
+    )
+    assert results == {
+        "listener-arn-0/certificate-arn": "listener-arn-0",
+        "listener-arn-0/certificate-arn-0": "listener-arn-0",
+    }
+
+
+def test_get_matching_alb_listener_arns_for_multiple_listeners(alb):
+    alb.expect_get_certificates_for_listener("listener-arn-0", 4)
+    alb.expect_get_certificates_for_listener("listener-arn-1", 2)
+    results = get_matching_alb_listener_arns_for_cert_arns(
+        [
+            "listener-arn-0/certificate-arn-0",
+            "listener-arn-0/certificate-arn-2",
+            "listener-arn-1/certificate-arn-1",
+        ],
+        ["listener-arn-0", "listener-arn-1"],
+    )
+    assert results == {
+        "listener-arn-0/certificate-arn-0": "listener-arn-0",
+        "listener-arn-0/certificate-arn-2": "listener-arn-0",
+        "listener-arn-1/certificate-arn-1": "listener-arn-1",
+    }
+
+
+def test_delete_cert_record_success(no_context_app, no_context_clean_db, alb):
+    with no_context_app.app_context():
+        service_instance = DedicatedALBServiceInstanceFactory.create(id="1234")
+        certificate = CertificateFactory.create(
+            service_instance=service_instance, iam_server_certificate_arn="arn1"
+        )
+        no_context_clean_db.session.commit()
+
+        assert len(Certificate.query.all()) == 1
+
+        alb.expect_remove_certificate_from_listener("1234", "arn1")
+        alb.expect_get_certificates_for_listener(service_instance.id)
+
+        delete_cert_record_and_resource(certificate, "1234")
+
+        assert len(Certificate.query.all()) == 0
+
+
+def test_delete_duplicate_cert_record_rollback(no_context_app, no_context_clean_db):
+    with no_context_app.app_context():
+        service_instance = DedicatedALBServiceInstanceFactory.create(id="1234")
+        certificate = CertificateFactory.create(
+            service_instance=service_instance, iam_server_certificate_arn="arn1"
+        )
+        no_context_clean_db.session.commit()
+
+        assert len(Certificate.query.all()) == 1
+
+        delete_duplicate_cert_db_record(certificate)
+        no_context_clean_db.session.rollback()
+
+        assert len(Certificate.query.all()) == 1
+
+
+def test_delete_duplicate_cert_record_commit(no_context_app, no_context_clean_db):
+    with no_context_app.app_context():
+        service_instance = DedicatedALBServiceInstanceFactory.create(id="1234")
+        certificate = CertificateFactory.create(
+            service_instance=service_instance, iam_server_certificate_arn="arn1"
+        )
+        ChallengeFactory.create(certificate_id=certificate.id)
+        no_context_clean_db.session.commit()
+
+        assert len(Certificate.query.all()) == 1
+
+        delete_duplicate_cert_db_record(certificate)
+        no_context_clean_db.session.commit()
+
+        assert len(Certificate.query.all()) == 0
+
+
+def test_delete_iam_server_certificate_success(iam_govcloud):
+    iam_govcloud.expects_delete_server_certificate("name1")
+
+    delete_iam_server_certificate("name1")
+
+
+def test_delete_iam_server_certificate_no_certificate(iam_govcloud):
+    iam_govcloud.expects_delete_server_certificate_returning_no_such_entity("name1")
+
+    delete_iam_server_certificate("name1")
+
+
+def test_delete_iam_server_certificate_unexpected_error(iam_govcloud):
+    with pytest.raises(ClientError):
+        iam_govcloud.expects_delete_server_certificate_returning_unexpected_error(
+            "name1"
+        )
+
+        delete_iam_server_certificate("name1")
+
+
+def test_delete_cert_record_and_resource_handle_exception(
+    no_context_clean_db, no_context_app
+):
+    with no_context_app.app_context():
+        service_instance = DedicatedALBServiceInstanceFactory.create(id="1234")
+        certificate = CertificateFactory.create(
+            service_instance=service_instance, iam_server_certificate_arn="arn1"
+        )
+
+        no_context_clean_db.session.commit()
+
+        assert len(Certificate.query.all()) == 1
+
+        class FakeALBTest:
+            def remove_listener_certificates(self, ListenerArn="", Certificates=[]):
+                raise Exception("remove_listener_certificates fail")
+
+        fakeAlbTest = FakeALBTest()
+        fakeLogger = FakeLogger()
+
+        delete_cert_record_and_resource(certificate, "1234", alb=fakeAlbTest, logger=fakeLogger)
+
+        assert len(Certificate.query.all()) == 1
+        assert(
+            fakeLogger.error_output[-1].strip()
+            == "Exception while deleting certificate: remove_listener_certificates fail"
+        )
+
+
+def test_delete_cert_record_and_resource_success(
+    no_context_clean_db, no_context_app, alb, iam_govcloud
+):
+    with no_context_app.app_context():
+        service_instance = DedicatedALBServiceInstanceFactory.create(id="1234")
+        certificate = CertificateFactory.create(
+            service_instance=service_instance,
+            iam_server_certificate_arn="arn1",
+            iam_server_certificate_name="name1",
+        )
+
+        no_context_clean_db.session.commit()
+
+        assert len(Certificate.query.all()) == 1
+
+        alb.expect_remove_certificate_from_listener(service_instance.id, "arn1")
+        alb.expect_get_certificates_for_listener(service_instance.id)
+        iam_govcloud.expects_delete_server_certificate("name1")
+        delete_cert_record_and_resource(certificate, "1234")
+
+        assert len(Certificate.query.all()) == 0
+
+
+def test_delete_cert_record_and_resource_no_listener(
+    no_context_clean_db, no_context_app
+):
+    with no_context_app.app_context():
+        service_instance = DedicatedALBServiceInstanceFactory.create(id="1234")
+        certificate = CertificateFactory.create(
+            service_instance=service_instance, iam_server_certificate_arn="arn1"
+        )
+
+        no_context_clean_db.session.commit()
+
+        assert len(Certificate.query.all()) == 1
+
+        delete_cert_record_and_resource(certificate, None)
+
+        assert len(Certificate.query.all()) == 0
+
+
+def test_delete_cert_record_and_resource_no_certificate(
+    no_context_clean_db, no_context_app, alb, iam_govcloud
+):
+    with no_context_app.app_context():
+        service_instance = DedicatedALBServiceInstanceFactory.create(id="1234")
+        certificate = CertificateFactory.create(
+            service_instance=service_instance,
+            iam_server_certificate_arn="arn1",
+            iam_server_certificate_name="name1",
+        )
+
+        no_context_clean_db.session.commit()
+
+        assert len(Certificate.query.all()) == 1
+
+        alb.expect_remove_certificate_from_listener(service_instance.id, "arn1")
+        alb.expect_get_certificates_for_listener(service_instance.id)
+        iam_govcloud.expects_delete_server_certificate_returning_no_such_entity("name1")
+        delete_cert_record_and_resource(certificate, "1234")
+
+        assert len(Certificate.query.all()) == 0
+
+
+def test_remove_duplicate_certs_with_active_operations(
+    no_context_clean_db, no_context_app, alb
+):
+    with no_context_app.app_context():
+        service_instance = DedicatedALBServiceInstanceFactory.create(id="1234")
+        certificate1 = CertificateFactory.create(
+            service_instance=service_instance, iam_server_certificate_arn="arn1"
+        )
+        CertificateFactory.create(
+            service_instance=service_instance, iam_server_certificate_arn="arn2"
+        )
+        OperationFactory.create(
+            service_instance=service_instance,
+            state=Operation.States.IN_PROGRESS.value,
+            action=Operation.Actions.RENEW.value,
+        )
+        service_instance.current_certificate_id = certificate1.id
+        no_context_clean_db.session.commit()
+
+        results = get_duplicate_certs_for_service(service_instance.id, DedicatedALBServiceInstance)
+        assert len(results) == 1
+
+        remove_duplicate_alb_certs(listener_arns=[service_instance.id])
+
+        # nothing should get deleted if there are active operations for a service instance
+        results = get_duplicate_certs_for_service(service_instance.id, DedicatedALBServiceInstance)
+        assert len(results) == 1
+
+
+def test_remove_duplicate_certs_for_service(no_context_clean_db, no_context_app, alb):
+    with no_context_app.app_context():
+        service_instance = DedicatedALBServiceInstanceFactory.create(id="1234")
+        certificate1 = CertificateFactory.create(
+            service_instance=service_instance, iam_server_certificate_arn="arn1"
+        )
+        CertificateFactory.create(
+            service_instance=service_instance, iam_server_certificate_arn="arn2"
+        )
+        CertificateFactory.create(
+            service_instance=service_instance, iam_server_certificate_arn="arn3"
+        )
+        service_instance.current_certificate_id = certificate1.id
+        no_context_clean_db.session.commit()
+
+        alb.expect_get_certificates_for_listener(
+            service_instance.id,
+            certificates=[{"CertificateArn": "arn2"}, {"CertificateArn": "arn3"}],
+        )
+
+        no_context_clean_db.session.commit()
+
+        results = get_duplicate_certs_for_service(service_instance.id, DedicatedALBServiceInstance)
+        assert len(results) == 2
+
+        alb.expect_remove_certificate_from_listener(service_instance.id, "arn2")
+        alb.expect_get_certificates_for_listener(service_instance.id)
+        alb.expect_remove_certificate_from_listener(service_instance.id, "arn3")
+        alb.expect_get_certificates_for_listener(service_instance.id)
+
+        fakeLogger = FakeLogger()
+
+        remove_duplicate_alb_certs(
+            listener_arns=[service_instance.id], logger=fakeLogger
+        )
+
+        assert (
+            fakeLogger.output[-1].strip()
+            == 'service_instance_duplicate_cert_count{service_instance_id="1234"} 0'
+        )
+
+        results = get_duplicate_certs_for_service(service_instance.id, DedicatedALBServiceInstance)
+        assert len(results) == 0
+
+
+def test_remove_certificate_from_listener_and_verify_removal_correctly_breaks():
+    class FakeALBTest:
+        def __init__(self):
+            self.attempts = 0
+
+        def remove_listener_certificates(self, ListenerArn="", Certificates=[]):
+            return True
+
+        def describe_listener_certificates(self, ListenerArn=""):
+            self.attempts += 1
+            return {
+                "Certificates": [{"CertificateArn": "listener-arn-0/certificate-arn"}],
+            }
+
+    fakeAlbTester = FakeALBTest()
+    remove_certificate_from_listener_and_verify_removal(
+        "listener-arn-0", "listener-arn-0/certificate-arn", alb=fakeAlbTester
+    )
+    # Only 10 attempts were made because the code breaks after 10 tries
+    assert fakeAlbTester.attempts == 10


### PR DESCRIPTION
## Changes proposed in this pull request:

There are two jobs in the pipeline that deal with duplicate certificates

- One that detects duplicate certificates for any service instances and reports them to Prometheus
- One that actually removes any duplicate certificates for any service instances and updates the Prometheus metrics

However, when the new dedicated ALB service instances were added in #293, this duplicate certificate code was not updated to handle duplicates for these service instances.

This PR updates the duplicate certificate check and removal code to also handle any duplicate certificates for dedicated ALB service instances.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

There should be no security issues, just refactoring code to handle and remove duplicate certificates for any dedicated ALB service instances. The only logging goes to Prometheus, which is an internal service only accessible to operators. 
