### PR TITLE
Fix duplicate cert removal

### DIFF
--- a/tests/integration/alb/test_alb_remove_duplicate_certs.py
+++ b/tests/integration/alb/test_alb_remove_duplicate_certs.py
@@ -1,6 +1,7 @@
 import pytest  # noqa F401
 
 from botocore.exceptions import ClientError
+from broker.extensions import config
 from broker.models import ALBServiceInstance, Operation
 from tests.lib.factories import (
     CertificateFactory,
@@ -20,6 +21,7 @@ from broker.duplicate_certs import (
 )
 from broker.models import Certificate
 
+
 class FakeLogger:
     def __init__(self):
         self.output = []
@@ -30,6 +32,7 @@ class FakeLogger:
 
     def error(self, input):
         self.error_output.append(input)
+
 
 def test_get_duplicate_certs_for_service(no_context_clean_db, no_context_app):
     with no_context_app.app_context():
@@ -47,7 +50,9 @@ def test_get_duplicate_certs_for_service(no_context_clean_db, no_context_app):
 
         no_context_clean_db.session.commit()
 
-        results = get_duplicate_certs_for_service(service_instance.id, ALBServiceInstance)
+        results = get_duplicate_certs_for_service(
+            service_instance.id, ALBServiceInstance
+        )
 
         assert len(results) == 2
         assert results == [certificate2, certificate3]
@@ -205,10 +210,12 @@ def test_delete_cert_record_and_resource_handle_exception(
         fakeAlbTest = FakeALBTest()
         fakeLogger = FakeLogger()
 
-        delete_cert_record_and_resource(certificate, "1234", alb=fakeAlbTest, logger=fakeLogger)
+        delete_cert_record_and_resource(
+            certificate, "1234", alb=fakeAlbTest, logger=fakeLogger
+        )
 
         assert len(Certificate.query.all()) == 1
-        assert(
+        assert (
             fakeLogger.error_output[-1].strip()
             == "Exception while deleting certificate: remove_listener_certificates fail"
         )
@@ -297,19 +304,26 @@ def test_remove_duplicate_certs_with_active_operations(
         service_instance.current_certificate_id = certificate1.id
         no_context_clean_db.session.commit()
 
-        results = get_duplicate_certs_for_service(service_instance.id, ALBServiceInstance)
+        results = get_duplicate_certs_for_service(
+            service_instance.id, ALBServiceInstance
+        )
         assert len(results) == 1
 
         remove_duplicate_alb_certs(alb_listener_arns=[service_instance.id])
 
         # nothing should get deleted if there are active operations for a service instance
-        results = get_duplicate_certs_for_service(service_instance.id, ALBServiceInstance)
+        results = get_duplicate_certs_for_service(
+            service_instance.id, ALBServiceInstance
+        )
         assert len(results) == 1
 
 
 def test_remove_duplicate_certs_for_service(no_context_clean_db, no_context_app, alb):
     with no_context_app.app_context():
-        service_instance = ALBServiceInstanceFactory.create(id="1234")
+        alb_listener_arns = config.ALB_LISTENER_ARNS
+        service_instance = ALBServiceInstanceFactory.create(
+            id="1234", alb_listener_arn=alb_listener_arns[0]
+        )
         certificate1 = CertificateFactory.create(
             service_instance=service_instance, iam_server_certificate_arn="arn1"
         )
@@ -323,32 +337,34 @@ def test_remove_duplicate_certs_for_service(no_context_clean_db, no_context_app,
         no_context_clean_db.session.commit()
 
         alb.expect_get_certificates_for_listener(
-            service_instance.id,
+            alb_listener_arns[0],
             certificates=[{"CertificateArn": "arn2"}, {"CertificateArn": "arn3"}],
         )
 
         no_context_clean_db.session.commit()
 
-        results = get_duplicate_certs_for_service(service_instance.id, ALBServiceInstance)
+        results = get_duplicate_certs_for_service(
+            service_instance.id, ALBServiceInstance
+        )
         assert len(results) == 2
 
-        alb.expect_remove_certificate_from_listener(service_instance.id, "arn2")
-        alb.expect_get_certificates_for_listener(service_instance.id)
-        alb.expect_remove_certificate_from_listener(service_instance.id, "arn3")
-        alb.expect_get_certificates_for_listener(service_instance.id)
+        alb.expect_remove_certificate_from_listener(alb_listener_arns[0], "arn2")
+        alb.expect_get_certificates_for_listener(alb_listener_arns[0])
+        alb.expect_remove_certificate_from_listener(alb_listener_arns[0], "arn3")
+        alb.expect_get_certificates_for_listener(alb_listener_arns[0])
 
         fakeLogger = FakeLogger()
 
-        remove_duplicate_alb_certs(
-            alb_listener_arns=[service_instance.id], logger=fakeLogger
-        )
+        remove_duplicate_alb_certs(logger=fakeLogger)
 
         assert (
             fakeLogger.output[-1].strip()
             == 'service_instance_duplicate_cert_count{service_instance_id="1234"} 0'
         )
 
-        results = get_duplicate_certs_for_service(service_instance.id, ALBServiceInstance)
+        results = get_duplicate_certs_for_service(
+            service_instance.id, ALBServiceInstance
+        )
         assert len(results) == 0
 
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fix listener ARNs input from config to `remove_duplicate_alb_certs`. `config.ALB_LISTENER_ARNS` and  `config.DEDICATED_ALB_LISTENER_ARNS` are already lists, so surrounding them with `[]` makes them a list of lists, which causes errors when passing these arguments as a `ListenerArn` to boto3 commands like [`describe_listener_certificates`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/elbv2/client/describe_listener_certificates.html)
- Upgrade integration tests to tests for the above scenario to avoid regression

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing bug in behavior
