### PR TITLE
fix unit test for removing duplicate certificates for dedicated ALBs

### DIFF
--- a/broker/config.py
+++ b/broker/config.py
@@ -203,17 +203,16 @@ class DockerConfig(Config):
         self.DNS_ROOT_DOMAIN = "domains.cloud.test"
         self.DATABASE_ENCRYPTION_KEY = "Local Dev Encrytpion Key"
         self.DEFAULT_CLOUDFRONT_ORIGIN = "cloud.local"
-        self.DEDICATED_ALB_LISTENER_ARNS = []
+        self.DEDICATED_ALB_LISTENER_ARNS = [
+            "dedicated-listener-arn-0",
+            "dedicated-listener-arn-1",
+        ]
         self.CLOUDFRONT_IAM_SERVER_CERTIFICATE_PREFIX = (
             "/cloudfront/external-domains-test/"
         )
         self.ALB_IAM_SERVER_CERTIFICATE_PREFIX = "/alb/external-domains-test/"
         self.REDIS_SSL = False
         self.ALB_LISTENER_ARNS = ["listener-arn-0", "listener-arn-1"]
-        self.ALB_DEDICATED_LISTENER_ARNS = [
-            "dedicated-listener-arn-0",
-            "dedicated-listener-arn-1",
-        ]
         self.AWS_COMMERCIAL_REGION = "us-west-1"
         self.AWS_COMMERCIAL_ACCESS_KEY_ID = "COMMERCIAL_FAKE_KEY_ID"
         self.AWS_COMMERCIAL_SECRET_ACCESS_KEY = "COMMERCIAL_FAKE_ACCESS_KEY"
@@ -261,7 +260,6 @@ class TestConfig(DockerConfig):
         # if you need to see what sqlalchemy is doing
         # self.SQLALCHEMY_ECHO = True
         self.IAM_CERTIFICATE_PROPAGATION_TIME = 0
-        self.DEDICATED_ALB_LISTENER_ARNS = []
 
 
 class MissingRedisError(RuntimeError):

--- a/tests/integration/dedicated_alb/test_dedicated_alb_remove_duplicate_certs.py
+++ b/tests/integration/dedicated_alb/test_dedicated_alb_remove_duplicate_certs.py
@@ -320,7 +320,7 @@ def test_remove_duplicate_certs_with_active_operations(
 
 def test_remove_duplicate_certs_for_service(no_context_clean_db, no_context_app, alb):
     with no_context_app.app_context():
-        alb_listener_arns = config.ALB_LISTENER_ARNS
+        alb_listener_arns = config.DEDICATED_ALB_LISTENER_ARNS
         service_instance = DedicatedALBServiceInstanceFactory.create(
             id="1234", alb_listener_arn=alb_listener_arns[0]
         )


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix unit test for removing duplicate certificates for dedicated ALBs

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing unit test
