### PR TITLE
fix tests for retries on deleting WAF web ACL & move file

### DIFF
--- a/broker/tasks/waf.py
+++ b/broker/tasks/waf.py
@@ -88,7 +88,7 @@ def _delete_web_acl_with_retries(operation_id, service_instance):
 
     while notDeleted:
         num_times += 1
-        if num_times >= 10:
+        if num_times > 10:
             logger.info(
                 "Failed to delete web ACL",
                 extra={

--- a/tests/integration/test_waf.py
+++ b/tests/integration/test_waf.py
@@ -95,7 +95,7 @@ def test_waf_delete_web_acl_gives_up_after_max_retries(
     with no_context_app.app_context():
         operation = factories.OperationFactory.create(service_instance=service_instance)
 
-        for i in range(0, 10):
+        for i in range(10):
             wafv2.expect_get_web_acl(
                 service_instance.dedicated_waf_web_acl_id,
                 service_instance.dedicated_waf_web_acl_name,


### PR DESCRIPTION
Related to https://github.com/cloud-gov/private/issues/1098

## Changes proposed in this pull request:

- fix tests for retries on deleting WAF web ACL to mock API calls the correct number of times
- update the delete web ACL code to retry 10 times before giving up 
- move file since it is an integration and not a unit test

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
