### PR TITLE
remove secrets file from pipeline in favor of Credhub

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -277,14 +277,8 @@ jobs:
   - get: src
     params: {depth: 1}
     trigger: true
-  - get: secrets
-    # Remember to manually trigger a new build if you upload a new version
-    # of the credentials file.
-    trigger: false
   - set_pipeline: ((name))
     file: src/ci/pipeline.yml
-    var_files:
-    - secrets/((name)).yml
 
 - name: test
   plan:
@@ -753,14 +747,6 @@ jobs:
 #  RESOURCES
 
 resources:
-
-- name: secrets
-  type: s3-iam
-  icon: cloud-lock
-  source:
-    region_name: ((concourse-varz-bucket-region))
-    bucket: ((concourse-varz-bucket))
-    versioned_file: ((name)).yml
 
 - name: src
   type: git


### PR DESCRIPTION
## Changes proposed in this pull request:

- remove secrets file from pipeline in favor of Credhub. Secrets for this pipeline configuration will now be read from Credhub

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Credhub is one of our approved secret stores. This PR is a step towards improving consistency for all of our pipelines to store their secrets in Credhub.
