### PR TITLE
fix acceptance test script

### DIFF
--- a/acceptance/run.sh
+++ b/acceptance/run.sh
@@ -12,6 +12,9 @@
 DATESTAMP=$(date +"%Y%m%d%H%M%S")
 INSTANCE="edb-test-${PLAN_NAME}-${DATESTAMP}"
 TTL=120
+# Disable AWS pager to avoid dependency on less.
+# see https://stackoverflow.com/a/68361849
+export AWS_PAGER=""
 
 required_vars=(
   CF_API_URL


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix acceptance test script to set AWS_PAGER="" so that AWS CLI output prints straight to console without requiring "less" utility

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, should just be fixing acceptance tests
