### PR TITLE
Update dedicated ALB logic and add more unit tests

### DIFF
--- a/broker/tasks/alb.py
+++ b/broker/tasks/alb.py
@@ -40,7 +40,7 @@ def get_lowest_used_alb(listener_arns) -> tuple[str, str]:
     return listener_data["LoadBalancerArn"], listener_data["ListenerArn"]
 
 
-def get_potential_listeners(service_instance):
+def get_potential_listeners_for_dedicated_instance(service_instance):
     # n.b. we're counting on our db count here
     # and elsewhere we rely on AWS's count.
 
@@ -88,7 +88,9 @@ def get_potential_listeners(service_instance):
 
 
 def get_lowest_dedicated_alb(service_instance, db):
-    potential_listeners = get_potential_listeners(service_instance)
+    potential_listeners = get_potential_listeners_for_dedicated_instance(
+        service_instance
+    )
     listener_arns = [listener.listener_arn for listener in potential_listeners]
     listener_arns.sort()  # this just makes testing easier
 

--- a/tests/integration/alb/test_alb_provisioning.py
+++ b/tests/integration/alb/test_alb_provisioning.py
@@ -39,51 +39,6 @@ from tests.integration.alb.test_alb_update import (
 # these subtasks when testing failure scenarios.
 
 
-def test_gets_lowest_used_alb(alb):
-    alb.expect_get_certificates_for_listener("listener-arn-0", 1)
-    alb.expect_get_listeners("listener-arn-0")
-    assert get_lowest_used_alb(["listener-arn-0"]) == (
-        "alb-listener-arn-0",
-        "listener-arn-0",
-    )
-    alb.expect_get_certificates_for_listener("listener-arn-0", 2)
-    alb.expect_get_certificates_for_listener("listener-arn-1", 1)
-    alb.expect_get_listeners("listener-arn-1")
-    assert get_lowest_used_alb(["listener-arn-0", "listener-arn-1"]) == (
-        "alb-listener-arn-1",
-        "listener-arn-1",
-    )
-    alb.expect_get_certificates_for_listener("listener-arn-1", 1)
-    alb.expect_get_certificates_for_listener("listener-arn-0", 2)
-    alb.expect_get_listeners("listener-arn-1")
-    assert get_lowest_used_alb(["listener-arn-1", "listener-arn-0"]) == (
-        "alb-listener-arn-1",
-        "listener-arn-1",
-    )
-    alb.expect_get_certificates_for_listener("listener-arn-1", 1)
-    alb.expect_get_certificates_for_listener("listener-arn-2", 2)
-    alb.expect_get_certificates_for_listener("listener-arn-0", 2)
-    alb.expect_get_listeners("listener-arn-1")
-    assert get_lowest_used_alb(
-        ["listener-arn-1", "listener-arn-2", "listener-arn-0"]
-    ) == ("alb-listener-arn-1", "listener-arn-1")
-    alb.expect_get_certificates_for_listener("listener-arn-0", 19)
-    alb.expect_get_certificates_for_listener("listener-arn-1", 0)
-    alb.expect_get_certificates_for_listener("listener-arn-2", 25)
-    alb.expect_get_certificates_for_listener("listener-arn-3", 20)
-    alb.expect_get_certificates_for_listener("listener-arn-4", 17)
-    alb.expect_get_listeners("listener-arn-1")
-    assert get_lowest_used_alb(
-        [
-            "listener-arn-0",
-            "listener-arn-1",
-            "listener-arn-2",
-            "listener-arn-3",
-            "listener-arn-4",
-        ]
-    ) == ("alb-listener-arn-1", "listener-arn-1")
-
-
 def test_provision_happy_path(
     client, dns, tasks, route53, iam_govcloud, simple_regex, alb
 ):

--- a/tests/lib/factories.py
+++ b/tests/lib/factories.py
@@ -10,6 +10,7 @@ from broker.models import (
     CDNServiceInstance,
     CDNDedicatedWAFServiceInstance,
     ALBServiceInstance,
+    DedicatedALBListener,
     DedicatedALBServiceInstance,
     MigrationServiceInstance,
 )
@@ -47,6 +48,13 @@ class ALBServiceInstanceFactory(BaseFactory):
 class DedicatedALBServiceInstanceFactory(BaseFactory):
     class Meta(object):
         model = DedicatedALBServiceInstance
+
+    id = Sequence(lambda n: "UUID {}".format(n))
+
+
+class DedicatedALBListenerFactory(BaseFactory):
+    class Meta(object):
+        model = DedicatedALBListener
 
     id = Sequence(lambda n: "UUID {}".format(n))
 

--- a/tests/lib/fake_alb.py
+++ b/tests/lib/fake_alb.py
@@ -59,6 +59,15 @@ class FakeALB(FakeAWS):
             {"ListenerArn": listener_arn},
         )
 
+    def expect_get_certificates_for_listener_error(self, listener_arn):
+        self.stubber.add_client_error(
+            "describe_listener_certificates",
+            service_error_code="NoSuchEntity",
+            service_message="Not found",
+            http_status_code=404,
+            expected_params={"ListenerArn": listener_arn},
+        )
+
     def expect_add_certificate_to_listener(self, listener_arn, iam_cert_arn):
         self.stubber.add_response(
             "add_listener_certificates",

--- a/tests/unit/test_alb.py
+++ b/tests/unit/test_alb.py
@@ -1,0 +1,76 @@
+import pytest
+
+from botocore.exceptions import ClientError
+
+from broker.tasks.alb import get_lowest_used_alb
+
+
+def test_gets_lowest_used_alb(alb):
+    alb.expect_get_certificates_for_listener("listener-arn-0", 1)
+    alb.expect_get_listeners("listener-arn-0")
+    assert get_lowest_used_alb(["listener-arn-0"]) == (
+        "alb-listener-arn-0",
+        "listener-arn-0",
+    )
+
+    alb.expect_get_certificates_for_listener("listener-arn-0", 2)
+    alb.expect_get_certificates_for_listener("listener-arn-1", 1)
+    alb.expect_get_listeners("listener-arn-1")
+    assert get_lowest_used_alb(["listener-arn-0", "listener-arn-1"]) == (
+        "alb-listener-arn-1",
+        "listener-arn-1",
+    )
+
+    alb.expect_get_certificates_for_listener("listener-arn-1", 1)
+    alb.expect_get_certificates_for_listener("listener-arn-0", 2)
+    alb.expect_get_listeners("listener-arn-1")
+    assert get_lowest_used_alb(["listener-arn-1", "listener-arn-0"]) == (
+        "alb-listener-arn-1",
+        "listener-arn-1",
+    )
+
+    alb.expect_get_certificates_for_listener("listener-arn-1", 1)
+    alb.expect_get_certificates_for_listener("listener-arn-2", 2)
+    alb.expect_get_certificates_for_listener("listener-arn-0", 2)
+    alb.expect_get_listeners("listener-arn-1")
+    assert get_lowest_used_alb(
+        ["listener-arn-1", "listener-arn-2", "listener-arn-0"]
+    ) == ("alb-listener-arn-1", "listener-arn-1")
+
+    alb.expect_get_certificates_for_listener("listener-arn-0", 19)
+    alb.expect_get_certificates_for_listener("listener-arn-1", 0)
+    alb.expect_get_certificates_for_listener("listener-arn-2", 25)
+    alb.expect_get_certificates_for_listener("listener-arn-3", 20)
+    alb.expect_get_certificates_for_listener("listener-arn-4", 17)
+    alb.expect_get_listeners("listener-arn-1")
+    assert get_lowest_used_alb(
+        [
+            "listener-arn-0",
+            "listener-arn-1",
+            "listener-arn-2",
+            "listener-arn-3",
+            "listener-arn-4",
+        ]
+    ) == ("alb-listener-arn-1", "listener-arn-1")
+
+    alb.expect_get_certificates_for_listener("listener-arn-0", 1)
+    alb.expect_get_certificates_for_listener("listener-arn-1", 1)
+    alb.expect_get_certificates_for_listener("listener-arn-2", 0)
+    alb.expect_get_listeners("listener-arn-2")
+    assert get_lowest_used_alb(
+        ["listener-arn-0", "listener-arn-1", "listener-arn-2"]
+    ) == (
+        "alb-listener-arn-2",
+        "listener-arn-2",
+    )
+
+
+def test_raises_error_getting_listener_certificates(alb):
+    alb.expect_get_certificates_for_listener_error("listener-arn-0")
+    with pytest.raises(ClientError):
+        get_lowest_used_alb(["listener-arn-0"])
+
+
+def test_raises_error_on_empty_input_list_albs():
+    with pytest.raises(RuntimeError):
+        get_lowest_used_alb([])

--- a/tests/unit/test_alb.py
+++ b/tests/unit/test_alb.py
@@ -3,7 +3,10 @@ import uuid
 
 from botocore.exceptions import ClientError
 
-from broker.tasks.alb import get_potential_listeners, get_lowest_used_alb
+from broker.tasks.alb import (
+    get_potential_listeners_for_dedicated_instance,
+    get_lowest_used_alb,
+)
 from tests.lib import factories
 
 
@@ -94,7 +97,9 @@ def test_get_potential_listeners_with_no_listeners_for_instance_org(
         no_context_clean_db.session.add(service_instance)
         no_context_clean_db.session.commit()
 
-        potential_listeners = get_potential_listeners(service_instance)
+        potential_listeners = get_potential_listeners_for_dedicated_instance(
+            service_instance
+        )
         assert potential_listeners == [listener]
 
 
@@ -114,7 +119,9 @@ def test_get_potential_listeners_with_listeners_for_instance_org(
         no_context_clean_db.session.add(service_instance)
         no_context_clean_db.session.commit()
 
-        potential_listeners = get_potential_listeners(service_instance)
+        potential_listeners = get_potential_listeners_for_dedicated_instance(
+            service_instance
+        )
         assert potential_listeners == [listener]
 
 
@@ -135,4 +142,4 @@ def test_get_potential_listeners_no_listeners_found(
         no_context_clean_db.session.commit()
 
         with pytest.raises(RuntimeError):
-            get_potential_listeners(service_instance)
+            get_potential_listeners_for_dedicated_instance(service_instance)


### PR DESCRIPTION
## Changes proposed in this pull request:

- Refactor logic for `get_lowest_dedicated_alb` into separate functions 
- Add unit tests
- Rename variables / add comments to clarify code behavior

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just refactoring code for clarity
