### PR TITLE
Update web ACL creation to use a predictable name

### DIFF
--- a/broker/config.py
+++ b/broker/config.py
@@ -57,6 +57,8 @@ class Config:
         # the maximum from AWS is 25, and we alert when we have 20 on a given alb
         self.MAX_CERTS_PER_ALB = 19
 
+        self.DEDICATED_WAF_NAME_PREFIX = f"cg-external-domains-{self.FLASK_ENV}"
+
 
 class AppConfig(Config):
     """Base class for apps running in Cloud Foundry"""

--- a/broker/tasks/waf.py
+++ b/broker/tasks/waf.py
@@ -34,9 +34,9 @@ def create_web_acl(operation_id: str, **kwargs):
         )
         return
 
-    waf_name = f"{service_instance.id}-dedicated-waf"
+    web_acl_name = generate_web_acl_name(service_instance)
     response = wafv2.create_web_acl(
-        Name=waf_name,
+        Name=web_acl_name,
         Scope="CLOUDFRONT",
         DefaultAction={"Allow": {}},
         Rules=[
@@ -51,14 +51,14 @@ def create_web_acl(operation_id: str, **kwargs):
                 "VisibilityConfig": {
                     "SampledRequestsEnabled": True,
                     "CloudWatchMetricsEnabled": True,
-                    "MetricName": f"{service_instance.id}-rate-limit-rule-group",
+                    "MetricName": f"{web_acl_name}-rate-limit-rule-group",
                 },
             }
         ],
         VisibilityConfig={
             "SampledRequestsEnabled": True,
             "CloudWatchMetricsEnabled": True,
-            "MetricName": waf_name,
+            "MetricName": web_acl_name,
         },
     )
 
@@ -93,6 +93,10 @@ def delete_web_acl(operation_id: str, **kwargs):
 
     db.session.add(service_instance)
     db.session.commit()
+
+
+def generate_web_acl_name(service_instance):
+    return f"{config.DEDICATED_WAF_NAME_PREFIX}-{service_instance.id}-dedicated-waf"
 
 
 def _delete_web_acl_with_retries(operation_id, service_instance):

--- a/tests/integration/cdn_dedicated_waf/provision.py
+++ b/tests/integration/cdn_dedicated_waf/provision.py
@@ -25,19 +25,16 @@ def subtest_provision_create_web_acl(tasks, wafv2, service_instance_id="4321"):
         CDNDedicatedWAFServiceInstance, service_instance_id
     )
     assert service_instance.dedicated_waf_web_acl_id
-    assert (
-        service_instance.dedicated_waf_web_acl_id
-        == f"{service_instance.id}-dedicated-waf-id"
+    web_acl_name = (
+        f"{config.DEDICATED_WAF_NAME_PREFIX}-{service_instance.id}-dedicated-waf"
     )
+    assert service_instance.dedicated_waf_web_acl_id == f"{web_acl_name}-id"
     assert service_instance.dedicated_waf_web_acl_name
-    assert (
-        service_instance.dedicated_waf_web_acl_name
-        == f"{service_instance.id}-dedicated-waf"
-    )
+    assert service_instance.dedicated_waf_web_acl_name == web_acl_name
     assert service_instance.dedicated_waf_web_acl_arn
     assert (
         service_instance.dedicated_waf_web_acl_arn
-        == f"arn:aws:wafv2::000000000000:global/webacl/{service_instance.id}-dedicated-waf"
+        == f"arn:aws:wafv2::000000000000:global/webacl/{web_acl_name}"
     )
 
 

--- a/tests/lib/fake_wafv2.py
+++ b/tests/lib/fake_wafv2.py
@@ -1,13 +1,14 @@
 import pytest
 
 from broker.aws import wafv2 as real_wafv2
+from broker.extensions import config
 from tests.lib.fake_aws import FakeAWS
 
 
 class FakeWAFV2(FakeAWS):
     def expect_create_web_acl(self, id: str, rule_group_arn: str):
         method = "create_web_acl"
-        waf_name = f"{id}-dedicated-waf"
+        waf_name = f"{config.DEDICATED_WAF_NAME_PREFIX}-{id}-dedicated-waf"
         request = {
             "Name": waf_name,
             "Scope": "CLOUDFRONT",
@@ -22,7 +23,7 @@ class FakeWAFV2(FakeAWS):
                     "VisibilityConfig": {
                         "SampledRequestsEnabled": True,
                         "CloudWatchMetricsEnabled": True,
-                        "MetricName": f"{id}-rate-limit-rule-group",
+                        "MetricName": f"{waf_name}-rate-limit-rule-group",
                     },
                 }
             ],


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/cg-provision/pull/1735

- Update web ACL creation logic to use a predictable name so that IAM permissions for managing these resources can be tightly scoped

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

These changes allow for more tightly scoped IAM permissions for creating/deleting WAF web ACLs. See https://github.com/cloud-gov/cg-provision/pull/1735.
