### PR TITLE
Fix more provision errors

### DIFF
--- a/broker/tasks/iam.py
+++ b/broker/tasks/iam.py
@@ -69,15 +69,16 @@ def upload_server_certificate(operation_id: int, **kwargs):
         "Arn"
     ]
 
+    db.session.add(service_instance)
+    db.session.add(certificate)
+    db.session.commit()
+
     tags = service_instance.tags if service_instance.tags else []
     iam.tag_server_certificate(
         ServerCertificateName=certificate.iam_server_certificate_name,
         Tags=tags,
     )
 
-    db.session.add(service_instance)
-    db.session.add(certificate)
-    db.session.commit()
     time.sleep(propagation_time)
 
 

--- a/broker/tasks/iam.py
+++ b/broker/tasks/iam.py
@@ -66,15 +66,15 @@ def upload_server_certificate(operation_id: int, **kwargs):
         "Arn"
     ]
 
-    db.session.add(service_instance)
-    db.session.add(certificate)
-    db.session.commit()
-
     tags = service_instance.tags if service_instance.tags else []
     iam.tag_server_certificate(
         ServerCertificateName=certificate.iam_server_certificate_name,
         Tags=tags,
     )
+
+    db.session.add(service_instance)
+    db.session.add(certificate)
+    db.session.commit()
 
     time.sleep(propagation_time)
 

--- a/broker/tasks/iam.py
+++ b/broker/tasks/iam.py
@@ -51,14 +51,11 @@ def upload_server_certificate(operation_id: int, **kwargs):
             CertificateChain=certificate.fullchain_pem,
         )
     except ClientError as e:
-        # TODO: there's an edge case here, where we uploaded the certificate but
-        # failed to persist the metadata to the database. If that happens, we really
-        # need to get the metadata back from IAM.
-        if (
-            e.response["Error"]["Code"] == "EntityAlreadyExistsException"
-            and certificate.iam_server_certificate_id is not None
-        ):
-            return
+        if e.response["Error"]["Code"] == "EntityAlreadyExistsException":
+            get_response = iam.get_server_certificate(
+                ServerCertificateName=certificate.iam_server_certificate_name,
+            )
+            response = get_response["ServerCertificate"]
         else:
             raise e
 

--- a/broker/tasks/route53.py
+++ b/broker/tasks/route53.py
@@ -345,8 +345,10 @@ def _create_health_checks(
     tags = service_instance.tags if service_instance.tags else []
 
     updated_health_checks = existing_health_checks
-    for domain_name in health_check_domains_to_create:
-        health_check_id = _create_health_check(service_instance.id, domain_name, tags)
+    for idx, domain_name in enumerate(health_check_domains_to_create):
+        health_check_id = _create_health_check(
+            idx, service_instance.id, domain_name, tags
+        )
         updated_health_checks.append(
             {
                 "domain_name": domain_name,
@@ -356,10 +358,10 @@ def _create_health_checks(
     return updated_health_checks
 
 
-def _create_health_check(service_instance_id, domain_name, tags):
+def _create_health_check(idx, service_instance_id, domain_name, tags):
     logger.info(f"Creating Route53 health check for {domain_name}")
     route53_response = route53.create_health_check(
-        CallerReference=f"create_health_check-{service_instance_id}-{domain_name}",
+        CallerReference=f"{service_instance_id}-{idx}",
         HealthCheckConfig={
             "Type": "HTTPS",
             "FullyQualifiedDomainName": domain_name,

--- a/tests/integration/cdn_dedicated_waf/provision.py
+++ b/tests/integration/cdn_dedicated_waf/provision.py
@@ -49,8 +49,8 @@ def subtest_provision_creates_health_checks(
     db.session.expunge_all()
     service_instance = db.session.get(instance_model, service_instance_id)
 
-    for domain_name in service_instance.domain_names:
-        route53.expect_create_health_check(service_instance.id, domain_name)
+    for idx, domain_name in enumerate(service_instance.domain_names):
+        route53.expect_create_health_check(service_instance.id, domain_name, idx)
         route53.expect_change_tags_for_resource(domain_name, service_instance.tags)
 
     tasks.run_queued_tasks_and_enqueue_dependents()

--- a/tests/integration/cdn_dedicated_waf/update.py
+++ b/tests/integration/cdn_dedicated_waf/update.py
@@ -16,7 +16,7 @@ def subtest_updates_health_checks(
     db.session.expunge_all()
     service_instance = db.session.get(instance_model, service_instance_id)
 
-    route53.expect_create_health_check(service_instance.id, "bar.com")
+    route53.expect_create_health_check(service_instance.id, "bar.com", 0)
     route53.expect_change_tags_for_resource("bar.com", service_instance.tags)
 
     delete_health_check = [

--- a/tests/lib/fake_iam.py
+++ b/tests/lib/fake_iam.py
@@ -41,7 +41,9 @@ class FakeIAM(FakeAWS):
         response = {
             "ServerCertificate": self.server_certificate_metadata_response(
                 name, cert, chain, path
-            )
+            ),
+            "CertificateBody": cert,
+            "CertificateChain": chain,
         }
         self.stubber.add_response(method, response, request)
 
@@ -58,9 +60,7 @@ class FakeIAM(FakeAWS):
                 "Arn": f"arn:aws:iam::000000000000:server-certificate{path}{name}",
                 "UploadDate": now,
                 "Expiration": three_months_from_now,
-            },
-            "CertificateBody": cert,
-            "CertificateChain": chain,
+            }
         }
 
     def expect_upload_server_certificate_raising_duplicate(

--- a/tests/lib/fake_route53.py
+++ b/tests/lib/fake_route53.py
@@ -206,14 +206,14 @@ class FakeRoute53(FakeAWS):
             "get_change", self._change_info(change_id, "INSYNC"), {"Id": change_id}
         )
 
-    def expect_create_health_check(self, id, domain_name):
+    def expect_create_health_check(self, id, domain_name, idx):
         health_check_id = f"{domain_name} ID"
         self.stubber.add_response(
             "create_health_check",
             {
                 "HealthCheck": {
                     "Id": health_check_id,
-                    "CallerReference": f"create_health_check-{id}-{domain_name}",
+                    "CallerReference": f"{id}-{idx}",
                     "HealthCheckConfig": {
                         "Type": "HTTPS",
                         "FullyQualifiedDomainName": domain_name,

--- a/tests/lib/fake_route53.py
+++ b/tests/lib/fake_route53.py
@@ -223,7 +223,7 @@ class FakeRoute53(FakeAWS):
                 "Location": "fake-check-location",
             },
             {
-                "CallerReference": f"create_health_check-{id}-{domain_name}",
+                "CallerReference": f"{id}-{idx}",
                 "HealthCheckConfig": {
                     "Type": "HTTPS",
                     "FullyQualifiedDomainName": domain_name,


### PR DESCRIPTION
Related to https://github.com/cloud-gov/private/issues/1098

## Changes proposed in this pull request:

- Fix logic for setting caller reference name when creating Route53 health checks to respect length limit
- Add logic for handling case where IAM server certificate was already uploaded but not persisted to the database. Add integration test for this case

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing bugs preventing resources from provisioning correctly
