### PR TITLE
fix expected response structure for integration test

### DIFF
--- a/tests/lib/fake_iam.py
+++ b/tests/lib/fake_iam.py
@@ -38,13 +38,17 @@ class FakeIAM(FakeAWS):
         request = {
             "ServerCertificateName": name,
         }
-        response = {
-            "ServerCertificate": self.server_certificate_metadata_response(
-                name, cert, chain, path
-            ),
-            "CertificateBody": cert,
-            "CertificateChain": chain,
-        }
+        response = {"ServerCertificate": {}}
+
+        response["ServerCertificate"].update(
+            self.server_certificate_metadata_response(name, cert, chain, path)
+        )
+        response["ServerCertificate"].update(
+            {
+                "CertificateBody": cert,
+                "CertificateChain": chain,
+            }
+        )
         self.stubber.add_response(method, response, request)
 
     def server_certificate_metadata_response(


### PR DESCRIPTION
## Changes proposed in this pull request:

Related https://github.com/cloud-gov/private/issues/1098

- see title

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
