### PR TITLE
fix pipeline for registering CDN with dedicated WAF plan in production

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -555,7 +555,7 @@ jobs:
   - task: register-broker-cdn-dedicated-waf
     file: pipeline-tasks/register-service-broker-and-set-plan-visibility.yml
     params:
-      <<: [*cf-creds-staging, *cdn-dedicated-waf-plan-visibility-params]
+      <<: [*cf-creds-production, *cdn-dedicated-waf-plan-visibility-params]
       # space-separated list of org names that should have the dedicated alb plan
       SERVICE_ORGANIZATION: ((production-cdn-dedicated-waf-plan-org-names))
   on_failure:


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/private/issues/1098

- see title

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing typo in pipeline 
