### PR TITLE
Fix logic waiting for distribution to be disabled

### DIFF
--- a/broker/tasks/cloudfront.py
+++ b/broker/tasks/cloudfront.py
@@ -223,9 +223,9 @@ def wait_for_distribution_disabled(operation_id: int, **kwargs):
     if service_instance.cloudfront_distribution_id is None:
         return
 
-    enabled = True
+    distribution_disabled = False
     num_times = 0
-    while enabled:
+    while not distribution_disabled:
         num_times += 1
         if num_times >= 60:
             logger.info(
@@ -243,7 +243,10 @@ def wait_for_distribution_disabled(operation_id: int, **kwargs):
             )
         except cloudfront.exceptions.NoSuchDistribution:
             return
-        enabled = status["Distribution"]["DistributionConfig"]["Enabled"]
+        distribution_disabled = (
+            status["Distribution"]["DistributionConfig"]["Enabled"] == False
+            and status["Distribution"]["Status"] == "Deployed"
+        )
 
 
 @huey.retriable_task

--- a/tests/integration/test_cloudfront.py
+++ b/tests/integration/test_cloudfront.py
@@ -1,0 +1,153 @@
+import pytest
+import uuid
+import random
+
+from broker.tasks.cloudfront import (
+    wait_for_distribution_disabled,
+)
+from broker.models import Operation
+
+from tests.lib import factories
+
+
+@pytest.fixture
+def service_instance_id():
+    return str(random.randrange(0, 10000))
+
+
+@pytest.fixture
+def operation_id():
+    return str(random.randrange(0, 10000))
+
+
+@pytest.fixture
+def cloudfront_distribution_arn():
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
+def service_instance(
+    clean_db,
+    operation_id,
+    service_instance_id,
+    cloudfront_distribution_arn,
+    instance_factory,
+):
+    service_instance = instance_factory.create(
+        id=service_instance_id,
+        domain_names=["example.com", "foo.com"],
+        domain_internal="fake1234.cloudfront.net",
+        route53_alias_hosted_zone="Z2FDTNDATAQYW2",
+        cloudfront_distribution_id="FakeDistributionId",
+        cloudfront_distribution_arn=cloudfront_distribution_arn,
+        cloudfront_origin_hostname="origin_hostname",
+        cloudfront_origin_path="origin_path",
+        origin_protocol_policy="https-only",
+        forwarded_headers=["HOST"],
+    )
+    new_cert = factories.CertificateFactory.create(
+        service_instance=service_instance,
+        private_key_pem="SOMEPRIVATEKEY",
+        iam_server_certificate_id="certificate_id",
+        leaf_pem="SOMECERTPEM",
+        fullchain_pem="FULLCHAINOFSOMECERTPEM",
+        id=1002,
+    )
+    current_cert = factories.CertificateFactory.create(
+        service_instance=service_instance,
+        private_key_pem="SOMEPRIVATEKEY",
+        iam_server_certificate_id="certificate_id",
+        id=1001,
+    )
+    factories.ChallengeFactory.create(
+        domain="example.com",
+        validation_contents="example txt",
+        certificate_id=1001,
+        answered=True,
+    )
+    factories.ChallengeFactory.create(
+        domain="foo.com",
+        validation_contents="foo txt",
+        certificate_id=1001,
+        answered=True,
+    )
+    factories.ChallengeFactory.create(
+        domain="example.com",
+        validation_contents="example txt",
+        certificate_id=1002,
+        answered=False,
+    )
+    factories.ChallengeFactory.create(
+        domain="foo.com",
+        validation_contents="foo txt",
+        certificate_id=1002,
+        answered=False,
+    )
+    service_instance.current_certificate = current_cert
+    service_instance.new_certificate = new_cert
+    clean_db.session.add(service_instance)
+    clean_db.session.add(current_cert)
+    clean_db.session.add(new_cert)
+    clean_db.session.commit()
+    clean_db.session.expunge_all()
+    factories.OperationFactory.create(
+        id=operation_id, service_instance=service_instance
+    )
+    return service_instance
+
+
+@pytest.mark.parametrize(
+    "instance_factory",
+    [
+        factories.CDNServiceInstanceFactory,
+        factories.CDNDedicatedWAFServiceInstanceFactory,
+    ],
+)
+def test_cloudfront_wait_distribution_disabled(
+    clean_db,
+    service_instance,
+    operation_id,
+    cloudfront,
+):
+    cloudfront.expect_get_distribution(
+        caller_reference="asdf",
+        domains=service_instance.domain_names,
+        certificate_id=service_instance.new_certificate.iam_server_certificate_id,
+        origin_hostname=service_instance.cloudfront_origin_hostname,
+        origin_path=service_instance.cloudfront_origin_path,
+        distribution_id=service_instance.cloudfront_distribution_id,
+        status="In progress",
+        enabled=True,
+    )
+    cloudfront.expect_get_distribution(
+        caller_reference="asdf",
+        domains=service_instance.domain_names,
+        certificate_id=service_instance.new_certificate.iam_server_certificate_id,
+        origin_hostname=service_instance.cloudfront_origin_hostname,
+        origin_path=service_instance.cloudfront_origin_path,
+        distribution_id=service_instance.cloudfront_distribution_id,
+        status="In progress",
+        enabled=False,
+    )
+    cloudfront.expect_get_distribution(
+        caller_reference="asdf",
+        domains=service_instance.domain_names,
+        certificate_id=service_instance.new_certificate.iam_server_certificate_id,
+        origin_hostname=service_instance.cloudfront_origin_hostname,
+        origin_path=service_instance.cloudfront_origin_path,
+        distribution_id=service_instance.cloudfront_distribution_id,
+        status="Deployed",
+        enabled=False,
+    )
+
+    wait_for_distribution_disabled.call_local(operation_id)
+
+    # asserts that all the mocked calls above were made
+    cloudfront.assert_no_pending_responses()
+
+    clean_db.session.expunge_all()
+
+    operation = clean_db.session.get(Operation, operation_id)
+    assert (
+        operation.step_description == "Waiting for CloudFront distribution to disable"
+    )

--- a/tests/lib/fake_cloudfront.py
+++ b/tests/lib/fake_cloudfront.py
@@ -305,7 +305,6 @@ class FakeCloudFront(FakeAWS):
         custom_error_responses: dict = None,
         include_le_bucket: bool = False,
         include_log_bucket: bool = True,
-        dedicated_waf_web_acl_arn: str = "",
     ) -> Dict[str, Any]:
         if forwarded_headers is None:
             forwarded_headers = ["HOST"]


### PR DESCRIPTION
## Changes proposed in this pull request:

We are getting this error when our acceptance tests run in CI:

```shell
botocore.errorfactory.DistributionNotDisabled: An error occurred (DistributionNotDisabled) when calling the DeleteDistribution operation: The distribution you are trying to delete has not been disabled., 
```

This error doesn't cause the tests or service deletion to ultimately fail, because it just retries until the distribution has been fully disabled and deletes it. However, it would be preferable to have the task which is supposed to wait for a distribution to be disabled, `wait_for_distribution_disabled`, to correctly wait long enough so that this error does not occur.

[The problem is that we need to wait not only for the status of the distribution to be disabled, but also for that change to have fully deployed before attempting the deletion](https://stackoverflow.com/questions/43077173/deleting-a-cloudfront-distribution-with-boto3).

This PR adds logic to wait_for_distribution_disabled to ensure that task waits until distribution is disabled and fully deployed before continuing. The PR also adds a small integration test to ensure that the new behavior is working as expected.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing a small bug in the broker behavior