### PR TITLE
Revert "Harden image"

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -239,9 +239,19 @@ jobs:
     params: {depth: 1}
     trigger: true
     passed: [reconfigure]
-  - get: external-domain-broker-testing
+
+  - put: dev-docker-image
+    # We push this docker image _only_ so that we can use it in the next task
+    # below.  :shrug: concourse.
+    params:
+      build: src
+      dockerfile: src/docker/Dockerfile.dev
+      tag_as_latest: true
+      cache: true
+
   - task: test
-    image: external-domain-broker-testing
+    # Run the tests using the image pushed above.
+    image: dev-docker-image
     config:
       platform: linux
       params:
@@ -421,12 +431,12 @@ jobs:
     - get: cf-staging
       trigger: true
       passed: [staging]
-    - get: external-domain-broker-testing
+    - get: dev-docker-image
     - get: test-timer
       trigger: true
   - in_parallel:
     - task: acceptance-cdn
-      image: external-domain-broker-testing
+      image: dev-docker-image
       timeout: 6h
       config:
         platform: linux
@@ -440,7 +450,7 @@ jobs:
         run:
           path: /app/acceptance/run.sh
     - task: acceptance-alb
-      image: external-domain-broker-testing
+      image: dev-docker-image
       timeout: 6h
       config:
         platform: linux
@@ -450,7 +460,7 @@ jobs:
         run:
           path: /app/acceptance/run.sh
     - task: acceptance-dedicated
-      image: external-domain-broker-testing
+      image: dev-docker-image
       timeout: 6h
       config:
         platform: linux
@@ -460,7 +470,7 @@ jobs:
         run:
           path: /app/acceptance/run.sh
     - task: acceptance-cdn-dedicated-waf
-      image: external-domain-broker-testing
+      image: dev-docker-image
       timeout: 6h
       config:
         platform: linux
@@ -573,12 +583,12 @@ jobs:
     - get: cf-production
       trigger: true
       passed: [production]
-    - get: external-domain-broker-testing
+    - get: dev-docker-image
     - get: test-timer
       trigger: true
   - in_parallel:
     - task: acceptance-cdn
-      image: external-domain-broker-testing
+      image: dev-docker-image
       timeout: 6h
       config:
         platform: linux
@@ -588,7 +598,7 @@ jobs:
         run:
           path: /app/acceptance/run.sh
     - task: acceptance-alb
-      image: external-domain-broker-testing
+      image: dev-docker-image
       timeout: 6h
       config:
         platform: linux
@@ -602,7 +612,7 @@ jobs:
         run:
           path: /app/acceptance/run.sh
     - task: acceptance-dedicated
-      image: external-domain-broker-testing
+      image: dev-docker-image
       timeout: 6h
       config:
         platform: linux
@@ -616,7 +626,7 @@ jobs:
         run:
           path: /app/acceptance/run.sh
     - task: acceptance-cdn-dedicated-waf
-      image: external-domain-broker-testing
+      image: dev-docker-image
       timeout: 6h
       config:
         platform: linux
@@ -731,14 +741,14 @@ resources:
     uri: https://github.com/cloud-gov/((name))
     branch: ((git-branch))
 
-- name: external-domain-broker-testing
-  type: registry-image
+- name: dev-docker-image
+  type: docker-image
+  icon: docker
   source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: external-domain-broker-testing
-    aws_region: us-gov-west-1
-    tag: latest
+    email: ((docker-email))
+    username: ((docker-username))
+    password: ((docker-password))
+    repository: ((docker-image-dev))
 
 - name: cf-dev
   type: cf

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,6 +1,4 @@
-ARG base_image
-
-FROM ${base_image} as base
+FROM python:3.11-slim as base
 
 # When building locally, these should be set to your UID/GID.  That way, any
 # files written to the $PWD mount will be owned by you.  This is not
@@ -11,33 +9,29 @@ ARG USER=app
 
 # In case the host user's GID is already in the base image.
 RUN grep -q ":$GID:" /etc/group \
-  || groupadd --gid="$GID" "$USER"
+ || groupadd --gid="$GID" "$USER"
 
 RUN useradd \
-  --home-dir="/home/$USER" \
-  --no-log-init \
-  --create-home \
-  --shell=/bin/bash \
-  --gid=$GID \
-  --uid=$UID \
-  --no-user-group \
-  --non-unique \
-  "$USER"
+      --home-dir="/home/$USER" \
+      --no-log-init \
+      --create-home \
+      --shell=/bin/bash \
+      --gid=$GID \
+      --uid=$UID \
+      --no-user-group \
+      --non-unique \
+      "$USER"
 
 RUN apt update \
-  && apt -y upgrade \
-  && apt install -y --no-install-recommends \
-  build-essential \
-  libpq-dev \
-  curl \
-  gnupg2 \
-  procps \
-  git \
-  lsb-release \
-  ca-certificates \
-  python3 \
-  python3-pip \
-  python3-dev
+ && apt -y upgrade \
+ && apt install -y --no-install-recommends \
+      build-essential \
+      libpq-dev \
+      curl \
+      gnupg2 \
+      procps \
+      git \
+      lsb-release
 
 # Install Fake Pebble LE server
 COPY --from=letsencrypt/pebble:latest /usr/bin/pebble /usr/bin/pebble
@@ -45,7 +39,7 @@ COPY --from=letsencrypt/pebble:latest /test/ /test/
 COPY --from=letsencrypt/pebble-challtestsrv:latest /usr/bin/pebble-challtestsrv /usr/bin/pebble-challtestsrv
 
 RUN cp /test/certs/pebble.minica.pem /usr/local/share/ca-certificates/pebble.crt \
-  && update-ca-certificates
+ && update-ca-certificates
 
 # Install Redis
 # cloud.gov currently supports redis 5.0
@@ -59,18 +53,18 @@ RUN curl -sSL "https://cli.run.pivotal.io/stable?release=linux64-binary&version=
 # Install PostgreSQL
 ENV PG_MAJOR=15
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main"\
-  > /etc/apt/sources.list.d/pgdg.list \
-  && curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
-  && apt update \
-  && DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends "postgresql-$PG_MAJOR"
+    > /etc/apt/sources.list.d/pgdg.list \
+ && curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
+ && apt update \
+ && apt install -y --no-install-recommends "postgresql-$PG_MAJOR"
 
 ENV PGDATA /tmp/data
 ENV PGCONFIG /tmp/data/postgresql.conf
 ENV PATH $PATH:/usr/lib/postgresql/$PG_MAJOR/bin
 
 RUN mkdir -p "$PGDATA" \
-  && chown -R "$USER:" "$PGDATA" \
-  && chmod 700 "$PGDATA"
+ && chown -R "$USER:" "$PGDATA" \
+ && chmod 700 "$PGDATA"
 
 ENV POSTGRES_HOST_AUTH_METHOD=trust
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Reverts cloud-gov/external-domain-broker#359

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

There are issues with the hardened container pipeline for this image, so reverting changes for now