### PR TITLE
update cloudwatch to use global region

### DIFF
--- a/broker/aws.py
+++ b/broker/aws.py
@@ -12,7 +12,6 @@ route53 = commercial_session.client("route53")
 iam_commercial = commercial_session.client("iam")
 cloudfront = commercial_session.client("cloudfront")
 shield = commercial_session.client("shield")
-cloudwatch_commercial = commercial_session.client("cloudwatch")
 
 # Some services need to explicitly use the global region
 commercial_global_session = boto3.Session(
@@ -21,6 +20,7 @@ commercial_global_session = boto3.Session(
     aws_secret_access_key=config.AWS_COMMERCIAL_SECRET_ACCESS_KEY,
 )
 wafv2 = commercial_global_session.client("wafv2")
+cloudwatch_commercial = commercial_global_session.client("cloudwatch")
 
 govcloud_session = boto3.Session(
     region_name=config.AWS_GOVCLOUD_REGION,


### PR DESCRIPTION
## Changes proposed in this pull request:

- update cloudwatch to create alarms in the correct region

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing broker behavior
