### PR TITLE
Fix: only tag certs when we have tags to tag them with

### DIFF
--- a/broker/tasks/iam.py
+++ b/broker/tasks/iam.py
@@ -66,11 +66,11 @@ def upload_server_certificate(operation_id: int, **kwargs):
         "Arn"
     ]
 
-    tags = service_instance.tags if service_instance.tags else []
-    iam.tag_server_certificate(
-        ServerCertificateName=certificate.iam_server_certificate_name,
-        Tags=tags,
-    )
+    if service_instance.tags:
+        iam.tag_server_certificate(
+            ServerCertificateName=certificate.iam_server_certificate_name,
+            Tags=service_instance.tags,
+        )
 
     db.session.add(service_instance)
     db.session.add(certificate)

--- a/tests/lib/fake_iam.py
+++ b/tests/lib/fake_iam.py
@@ -29,7 +29,9 @@ class FakeIAM(FakeAWS):
             "ServerCertificateName": name,
             "Tags": tags,
         }
-        self.stubber.add_response(method, {}, request)
+        # sending an empty tags causes an error in IAM.
+        if tags != []:
+            self.stubber.add_response(method, {}, request)
 
     def expect_get_server_certificate(
         self, name: str, cert: str, chain: str, path: str


### PR DESCRIPTION
## Changes proposed in this pull request:

- only tag certs when we have tags to tag them with

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None