### PR TITLE
Fix: looser error code checking and log codes when it fails

### DIFF
--- a/broker/tasks/iam.py
+++ b/broker/tasks/iam.py
@@ -58,7 +58,7 @@ def upload_server_certificate(operation_id: int, **kwargs):
             response = get_response["ServerCertificate"]
         else:
             logger.error(
-                f"Got this coe uploading server certificate: {e.response['Error']}"
+                f"Got this code uploading server certificate: {e.response['Error']}"
             )
             raise e
 

--- a/broker/tasks/iam.py
+++ b/broker/tasks/iam.py
@@ -51,12 +51,15 @@ def upload_server_certificate(operation_id: int, **kwargs):
             CertificateChain=certificate.fullchain_pem,
         )
     except ClientError as e:
-        if e.response["Error"]["Code"] == "EntityAlreadyExistsException":
+        if "EntityAlreadyExists" in e.response["Error"]["Code"]:
             get_response = iam.get_server_certificate(
                 ServerCertificateName=certificate.iam_server_certificate_name,
             )
             response = get_response["ServerCertificate"]
         else:
+            logger.error(
+                f"Got this coe uploading server certificate: {e.response['Error']}"
+            )
             raise e
 
     certificate.iam_server_certificate_id = response["ServerCertificateMetadata"][

--- a/tests/lib/fake_iam.py
+++ b/tests/lib/fake_iam.py
@@ -74,7 +74,8 @@ class FakeIAM(FakeAWS):
     ):
         self.stubber.add_client_error(
             "upload_server_certificate",
-            service_error_code="EntityAlreadyExistsException",
+            # asdf here is to test looser matching here
+            service_error_code="asdfEntityAlreadyExistsException",
             service_message="already got one",
             expected_params={
                 "Path": path,


### PR DESCRIPTION
## Changes proposed in this pull request:

- use a substring check on error code, since we seem to be not matching right now
- log when our error code match fails, so we can see why we fail if this doesn't work


## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None