### PR TITLE
Refactor code

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,13 @@ from tests.lib.cf import (
     organization_guid,
     mocked_cf_api,
 )  # noqa 41
+from tests.lib.identifiers import (
+    service_instance_id,
+    operation_id,
+    new_cert_id,
+    current_cert_id,
+    cloudfront_distribution_arn,
+)  # noqa 41
 
 
 def pytest_configure(config):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,7 @@ from tests.lib.identifiers import (
     new_cert_id,
     current_cert_id,
     cloudfront_distribution_arn,
+    protection_id,
 )  # noqa 41
 
 

--- a/tests/integration/cdn/test_cdn_renewals.py
+++ b/tests/integration/cdn/test_cdn_renewals.py
@@ -181,6 +181,7 @@ def subtest_renew_retrieves_certificate(tasks):
 
 
 def subtest_renewal_removes_certificate_from_iam(tasks, iam_govcloud):
+    iam_govcloud.expect_get_server_certificate("certificate_name")
     iam_govcloud.expects_delete_server_certificate("certificate_name")
 
     tasks.run_queued_tasks_and_enqueue_dependents()

--- a/tests/integration/dedicated_alb/test_dedicated_alb_renewals.py
+++ b/tests/integration/dedicated_alb/test_dedicated_alb_renewals.py
@@ -230,6 +230,7 @@ def subtest_renewal_removes_certificate_from_alb(tasks, alb):
 
 
 def subtest_renewal_removes_certificate_from_iam(tasks, iam_govcloud):
+    iam_govcloud.expect_get_server_certificate("certificate_name")
     iam_govcloud.expects_delete_server_certificate("certificate_name")
 
     tasks.run_queued_tasks_and_enqueue_dependents()

--- a/tests/integration/test_cloudfront.py
+++ b/tests/integration/test_cloudfront.py
@@ -11,21 +11,6 @@ from tests.lib import factories
 
 
 @pytest.fixture
-def service_instance_id():
-    return str(random.randrange(0, 10000))
-
-
-@pytest.fixture
-def operation_id():
-    return str(random.randrange(0, 10000))
-
-
-@pytest.fixture
-def cloudfront_distribution_arn():
-    return str(uuid.uuid4())
-
-
-@pytest.fixture
 def service_instance(
     clean_db,
     operation_id,

--- a/tests/integration/test_cloudwatch.py
+++ b/tests/integration/test_cloudwatch.py
@@ -1,6 +1,4 @@
 import pytest
-import uuid
-import random
 
 from botocore.exceptions import WaiterError
 
@@ -14,21 +12,6 @@ from broker.extensions import config
 from broker.models import Operation, CDNDedicatedWAFServiceInstance
 
 from tests.lib import factories
-
-
-@pytest.fixture
-def service_instance_id():
-    return str(random.randrange(0, 10000))
-
-
-@pytest.fixture
-def operation_id():
-    return str(random.randrange(0, 10000))
-
-
-@pytest.fixture
-def cloudfront_distribution_arn():
-    return str(uuid.uuid4())
 
 
 @pytest.fixture

--- a/tests/integration/test_iam_idempotent.py
+++ b/tests/integration/test_iam_idempotent.py
@@ -10,6 +10,7 @@ from broker.extensions import db
 from broker.models import CDNServiceInstance, Operation, Certificate
 
 from tests.lib import factories
+from tests.lib.identifiers import get_server_certificate_name
 
 
 @pytest.fixture
@@ -94,7 +95,7 @@ def alb_service_instance(
         iam_server_certificate_id="certificate_id",
         leaf_pem="SOMECERTPEM",
         fullchain_pem="FULLCHAINOFSOMECERTPEM",
-        iam_server_certificate_name=_get_server_certificate_name(
+        iam_server_certificate_name=get_server_certificate_name(
             service_instance_id, new_cert_id
         ),
         id=new_cert_id,
@@ -103,7 +104,7 @@ def alb_service_instance(
         service_instance=service_instance,
         private_key_pem="SOMEPRIVATEKEY",
         iam_server_certificate_id="certificate_id",
-        iam_server_certificate_name=_get_server_certificate_name(
+        iam_server_certificate_name=get_server_certificate_name(
             service_instance_id, current_cert_id
         ),
         id=current_cert_id,
@@ -144,11 +145,6 @@ def alb_service_instance(
     return service_instance
 
 
-def _get_server_certificate_name(instance_id, certificate_id):
-    today = date.today().isoformat()
-    return f"{instance_id}-{today}-{certificate_id}"
-
-
 def test_reupload_certificate_ok(
     clean_db,
     iam_commercial,
@@ -164,14 +160,14 @@ def test_reupload_certificate_ok(
     assert today == simple_regex(r"^\d\d\d\d-\d\d-\d\d$")
 
     iam_commercial.expect_upload_server_certificate(
-        name=_get_server_certificate_name(service_instance_id, certificate.id),
+        name=get_server_certificate_name(service_instance_id, certificate.id),
         cert=certificate.leaf_pem,
         private_key=certificate.private_key_pem,
         chain=certificate.fullchain_pem,
         path="/cloudfront/external-domains-test/",
     )
     iam_commercial.expect_tag_server_certificate(
-        _get_server_certificate_name(service_instance_id, certificate.id),
+        get_server_certificate_name(service_instance_id, certificate.id),
         [],
     )
 
@@ -203,21 +199,21 @@ def test_upload_certificate_already_exists(
     today = date.today().isoformat()
     assert today == simple_regex(r"^\d\d\d\d-\d\d-\d\d$")
 
+    server_certificate_name = get_server_certificate_name(
+        service_instance_id, certificate.id
+    )
     iam_commercial.expect_upload_server_certificate_raising_duplicate(
-        name=_get_server_certificate_name(service_instance_id, certificate.id),
+        name=server_certificate_name,
         cert=certificate.leaf_pem,
         private_key=certificate.private_key_pem,
         chain=certificate.fullchain_pem,
         path="/cloudfront/external-domains-test/",
     )
     iam_commercial.expect_get_server_certificate(
-        name=_get_server_certificate_name(service_instance_id, certificate.id),
-        cert=certificate.leaf_pem,
-        chain=certificate.fullchain_pem,
-        path="/cloudfront/external-domains-test/",
+        name=server_certificate_name,
     )
     iam_commercial.expect_tag_server_certificate(
-        _get_server_certificate_name(service_instance_id, certificate.id),
+        server_certificate_name,
         [],
     )
 
@@ -231,13 +227,10 @@ def test_delete_previous_server_certificate_happy_path(
 ):
     certificate = clean_db.session.get(Certificate, new_cert_id)
     iam_govcloud.expect_get_server_certificate(
-        _get_server_certificate_name(alb_service_instance.id, new_cert_id),
-        cert=certificate.leaf_pem,
-        chain=certificate.fullchain_pem,
-        path="/cloudfront/external-domains-test/",
+        get_server_certificate_name(alb_service_instance.id, new_cert_id),
     )
     iam_govcloud.expects_delete_server_certificate(
-        _get_server_certificate_name(alb_service_instance.id, new_cert_id),
+        get_server_certificate_name(alb_service_instance.id, new_cert_id),
     )
 
     delete_previous_server_certificate.call_local(operation_id)
@@ -255,13 +248,10 @@ def test_delete_previous_server_certificate_unexpected_error(
 ):
     certificate = clean_db.session.get(Certificate, new_cert_id)
     iam_govcloud.expect_get_server_certificate(
-        _get_server_certificate_name(alb_service_instance.id, new_cert_id),
-        cert=certificate.leaf_pem,
-        chain=certificate.fullchain_pem,
-        path="/cloudfront/external-domains-test/",
+        get_server_certificate_name(alb_service_instance.id, new_cert_id),
     )
     iam_govcloud.expects_delete_server_certificate_unexpected_error(
-        _get_server_certificate_name(alb_service_instance.id, new_cert_id),
+        get_server_certificate_name(alb_service_instance.id, new_cert_id),
     )
 
     with pytest.raises(Exception):
@@ -274,7 +264,7 @@ def test_delete_previous_server_certificate_already_deleted(
     clean_db, iam_govcloud, alb_service_instance, operation_id, new_cert_id
 ):
     iam_govcloud.expects_get_server_certificate_returning_no_such_entity(
-        _get_server_certificate_name(alb_service_instance.id, new_cert_id),
+        get_server_certificate_name(alb_service_instance.id, new_cert_id),
     )
     delete_previous_server_certificate.call_local(operation_id)
 
@@ -290,10 +280,10 @@ def test_delete_previous_server_certificate_error_on_get_server_certificate(
     clean_db, iam_govcloud, alb_service_instance, operation_id, new_cert_id
 ):
     iam_govcloud.expects_get_server_certificate_unexpected_error(
-        _get_server_certificate_name(alb_service_instance.id, new_cert_id),
+        get_server_certificate_name(alb_service_instance.id, new_cert_id),
     )
     iam_govcloud.expects_delete_server_certificate_access_denied(
-        _get_server_certificate_name(alb_service_instance.id, new_cert_id),
+        get_server_certificate_name(alb_service_instance.id, new_cert_id),
     )
 
     with pytest.raises(Exception):

--- a/tests/integration/test_route53.py
+++ b/tests/integration/test_route53.py
@@ -1,6 +1,4 @@
 import pytest
-import uuid
-import random
 
 from broker.tasks.route53 import (
     create_health_checks,
@@ -11,21 +9,6 @@ from broker.tasks.route53 import (
 from broker.models import CDNDedicatedWAFServiceInstance, Operation
 
 from tests.lib import factories
-
-
-@pytest.fixture
-def service_instance_id():
-    return str(random.randrange(0, 10000))
-
-
-@pytest.fixture
-def operation_id():
-    return str(random.randrange(0, 10000))
-
-
-@pytest.fixture
-def cloudfront_distribution_arn():
-    return str(uuid.uuid4())
 
 
 @pytest.fixture

--- a/tests/integration/test_shield.py
+++ b/tests/integration/test_shield.py
@@ -1,6 +1,4 @@
 import pytest
-import uuid
-import random
 
 from broker.tasks.shield import (
     associate_health_check,
@@ -10,26 +8,6 @@ from broker.tasks.shield import (
 from broker.models import CDNDedicatedWAFServiceInstance, Operation
 
 from tests.lib import factories
-
-
-@pytest.fixture
-def service_instance_id():
-    return str(random.randrange(0, 10000))
-
-
-@pytest.fixture
-def operation_id():
-    return str(random.randrange(0, 10000))
-
-
-@pytest.fixture
-def protection_id():
-    return str(uuid.uuid4())
-
-
-@pytest.fixture
-def cloudfront_distribution_arn():
-    return str(uuid.uuid4())
 
 
 @pytest.fixture

--- a/tests/integration/test_waf.py
+++ b/tests/integration/test_waf.py
@@ -1,32 +1,10 @@
 import pytest  # noqa F401
-import uuid
-import random
 
 from broker.extensions import db, config
 
 from broker.models import CDNDedicatedWAFServiceInstance, Operation
 from broker.tasks import waf
 from tests.lib import factories
-
-
-@pytest.fixture
-def protection_id():
-    return str(uuid.uuid4())
-
-
-@pytest.fixture
-def service_instance_id():
-    return str(random.randrange(0, 10000))
-
-
-@pytest.fixture
-def operation_id():
-    return str(random.randrange(0, 10000))
-
-
-@pytest.fixture
-def cloudfront_distribution_arn():
-    return str(uuid.uuid4())
 
 
 @pytest.fixture

--- a/tests/lib/fake_iam.py
+++ b/tests/lib/fake_iam.py
@@ -33,12 +33,10 @@ class FakeIAM(FakeAWS):
         if tags != []:
             self.stubber.add_response(method, {}, request)
 
-    def expect_get_server_certificate(self, name: str):
+    def expect_get_server_certificate(
+        self, name: str, cert: str = "fake-cert", chain: str = "fake-chain"
+    ):
         path = "/cloudfront/external-domains-test/"
-        # these are just fake values for the response
-        cert = "fake-cert"
-        chain = "fake-chain"
-
         method = "get_server_certificate"
         request = {
             "ServerCertificateName": name,

--- a/tests/lib/fake_iam.py
+++ b/tests/lib/fake_iam.py
@@ -33,9 +33,12 @@ class FakeIAM(FakeAWS):
         if tags != []:
             self.stubber.add_response(method, {}, request)
 
-    def expect_get_server_certificate(
-        self, name: str, cert: str, chain: str, path: str
-    ):
+    def expect_get_server_certificate(self, name: str):
+        path = "/cloudfront/external-domains-test/"
+        # these are just fake values for the response
+        cert = "fake-cert"
+        chain = "fake-chain"
+
         method = "get_server_certificate"
         request = {
             "ServerCertificateName": name,

--- a/tests/lib/identifiers.py
+++ b/tests/lib/identifiers.py
@@ -1,6 +1,7 @@
 import pytest
 import random
 import uuid
+from datetime import date
 
 
 @pytest.fixture
@@ -31,3 +32,8 @@ def cloudfront_distribution_arn():
 @pytest.fixture
 def protection_id():
     return str(uuid.uuid4())
+
+
+def get_server_certificate_name(instance_id, certificate_id):
+    today = date.today().isoformat()
+    return f"{instance_id}-{today}-{certificate_id}"

--- a/tests/lib/identifiers.py
+++ b/tests/lib/identifiers.py
@@ -26,3 +26,8 @@ def current_cert_id():
 @pytest.fixture
 def cloudfront_distribution_arn():
     return str(uuid.uuid4())
+
+
+@pytest.fixture
+def protection_id():
+    return str(uuid.uuid4())

--- a/tests/lib/identifiers.py
+++ b/tests/lib/identifiers.py
@@ -1,0 +1,28 @@
+import pytest
+import random
+import uuid
+
+
+@pytest.fixture
+def service_instance_id():
+    return str(random.randrange(0, 10000))
+
+
+@pytest.fixture
+def operation_id():
+    return str(random.randrange(0, 10000))
+
+
+@pytest.fixture
+def new_cert_id():
+    return str(random.randrange(0, 10000))
+
+
+@pytest.fixture
+def current_cert_id():
+    return str(random.randrange(0, 10000))
+
+
+@pytest.fixture
+def cloudfront_distribution_arn():
+    return str(uuid.uuid4())

--- a/tests/lib/update.py
+++ b/tests/lib/update.py
@@ -135,6 +135,7 @@ def subtest_update_removes_certificate_from_iam(
     tasks, iam, instance_model, service_instance_id="4321"
 ):
     server_certificate_name = f"{service_instance_id}-{date.today().isoformat()}-1"
+    iam.expect_get_server_certificate(server_certificate_name)
     iam.expects_delete_server_certificate(server_certificate_name)
 
     tasks.run_queued_tasks_and_enqueue_dependents()


### PR DESCRIPTION
## Changes proposed in this pull request:

- Refactor logic for deleting server certificates to check if they exist first, then only attempt deletion if the certificate does exist
- Moved common test fixtures for identifiers to shared lib
- Update `expect_get_server_certificate` on fake IAM service to use dummy values for cert and chain, which makes testing much less cumbersome

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just refactoring code for clarity and maintainability
