### PR TITLE
update image to install awscli through python

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -80,7 +80,10 @@ RUN mkdir -p "$PGDATA" \
 
 ENV POSTGRES_HOST_AUTH_METHOD=trust
 
-RUN apt install -y --no-install-recommends awscli jq
+RUN apt install -y --no-install-recommends jq
+
+# Install awscli using python
+RUN python -m pip install awscli
 
 # Install local python packages
 RUN python -m pip install --upgrade pip


### PR DESCRIPTION
## Changes proposed in this pull request:

- Installs awscli through python rather than ubuntu package

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Fixing acceptance tests by installing awscli using python
