### PR TITLE
Fix route53 create health check behavior on instance type update

### DIFF
--- a/broker/tasks/route53.py
+++ b/broker/tasks/route53.py
@@ -247,7 +247,7 @@ def create_health_checks(operation_id: int, **kwargs):
     created_health_checks = _create_health_checks(
         service_instance,
         service_instance.domain_names,
-        service_instance.route53_health_checks,
+        [],
     )
     service_instance.route53_health_checks = created_health_checks
     flag_modified(service_instance, "route53_health_checks")

--- a/broker/tasks/route53.py
+++ b/broker/tasks/route53.py
@@ -244,10 +244,15 @@ def create_health_checks(operation_id: int, **kwargs):
 
     logger.info(f'Creating health check(s) for "{service_instance.domain_names}"')
 
+    if service_instance.route53_health_checks is None:
+        current_health_checks = []
+    else:
+        current_health_checks = service_instance.route53_health_checks
+
     created_health_checks = _create_health_checks(
         service_instance,
         service_instance.domain_names,
-        [],
+        current_health_checks,
     )
     service_instance.route53_health_checks = created_health_checks
     flag_modified(service_instance, "route53_health_checks")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,9 @@ from tests.lib.fake_wafv2 import wafv2  # noqa F401
 from tests.lib.fake_shield import shield  # noqa F401
 from tests.lib.fake_cloudwatch import cloudwatch_commercial  # noqa F401
 from tests.lib.simple_regex import simple_regex  # noqa F401
+from tests.lib.cdn.instances import (
+    unmigrated_cdn_service_instance_operation_id,
+)  # noqa F401
 from tests.lib.dns import dns  # noqa 401
 from tests.lib.tasks import tasks  # noqa 401
 from tests.lib.cf import (

--- a/tests/integration/alb/test_alb_renewals.py
+++ b/tests/integration/alb/test_alb_renewals.py
@@ -29,7 +29,7 @@ from tests.integration.alb.test_alb_update import (
     subtest_update_creates_private_key_and_csr,
 )
 from tests.lib.alb.update import (
-    subtest_removes_certificate_from_alb,
+    subtest_removes_previous_certificate_from_alb,
 )
 from tests.lib.factories import (
     ALBServiceInstanceFactory,
@@ -140,7 +140,7 @@ def test_scan_for_expiring_certs_alb_happy_path(
     subtest_provision_adds_certificate_to_alb(tasks, alb)
     subtest_provision_provisions_ALIAS_records(tasks, route53, instance_model)
     subtest_provision_waits_for_route53_changes(tasks, route53, instance_model)
-    subtest_removes_certificate_from_alb(
+    subtest_removes_previous_certificate_from_alb(
         tasks, alb, "listener-arn-0", "certificate_arn"
     )
     subtest_renewal_removes_certificate_from_iam(tasks, iam_govcloud)

--- a/tests/integration/alb/test_alb_update.py
+++ b/tests/integration/alb/test_alb_update.py
@@ -20,7 +20,7 @@ from tests.lib.update import (
 from tests.lib.alb.update import (
     subtest_update_uploads_new_cert,
     subtest_update_provisions_ALIAS_records,
-    subtest_removes_certificate_from_alb,
+    subtest_removes_previous_certificate_from_alb,
 )
 
 
@@ -41,7 +41,7 @@ def subtest_update_happy_path(
     subtest_update_adds_certificate_to_alb(tasks, alb, instance_model)
     subtest_update_provisions_ALIAS_records(tasks, route53, instance_model)
     subtest_waits_for_dns_changes(tasks, route53, instance_model)
-    subtest_removes_certificate_from_alb(
+    subtest_removes_previous_certificate_from_alb(
         tasks,
         alb,
         "listener-arn-0",

--- a/tests/integration/dedicated_alb/test_dedicated_alb_renewals.py
+++ b/tests/integration/dedicated_alb/test_dedicated_alb_renewals.py
@@ -27,7 +27,7 @@ from tests.lib.alb.provision import (
     subtest_provision_retrieves_certificate,
 )
 from tests.lib.alb.update import (
-    subtest_removes_certificate_from_alb,
+    subtest_removes_previous_certificate_from_alb,
 )
 from tests.lib.update import (
     subtest_update_creates_private_key_and_csr,
@@ -146,7 +146,9 @@ def test_scan_for_expiring_certs_alb_happy_path(
     subtest_provision_adds_certificate_to_alb(tasks, alb)
     subtest_provision_provisions_ALIAS_records(tasks, route53, instance_model)
     subtest_provision_waits_for_route53_changes(tasks, route53, instance_model)
-    subtest_removes_certificate_from_alb(tasks, alb, "our-arn-0", "certificate_arn")
+    subtest_removes_previous_certificate_from_alb(
+        tasks, alb, "our-arn-0", "certificate_arn"
+    )
     subtest_renewal_removes_certificate_from_iam(tasks, iam_govcloud)
     subtest_provision_marks_operation_as_succeeded(tasks, instance_model)
 

--- a/tests/integration/dedicated_alb/test_dedicated_alb_update.py
+++ b/tests/integration/dedicated_alb/test_dedicated_alb_update.py
@@ -24,7 +24,7 @@ from tests.lib.update import (
 from tests.lib.alb.update import (
     subtest_update_uploads_new_cert,
     subtest_update_provisions_ALIAS_records,
-    subtest_removes_certificate_from_alb,
+    subtest_removes_previous_certificate_from_alb,
 )
 
 
@@ -45,7 +45,7 @@ def subtest_update_happy_path(
     subtest_update_adds_certificate_to_alb(tasks, alb)
     subtest_update_provisions_ALIAS_records(tasks, route53, instance_model)
     subtest_waits_for_dns_changes(tasks, route53, instance_model)
-    subtest_removes_certificate_from_alb(
+    subtest_removes_previous_certificate_from_alb(
         tasks,
         alb,
         "our-arn-0",

--- a/tests/integration/plan_updates/test_migration_update_to_alb.py
+++ b/tests/integration/plan_updates/test_migration_update_to_alb.py
@@ -25,7 +25,7 @@ from tests.integration.alb.test_alb_renewals import (
     subtest_renewal_removes_certificate_from_iam,
 )
 from tests.lib.alb.update import (
-    subtest_removes_certificate_from_alb,
+    subtest_removes_previous_certificate_from_alb,
 )
 
 from broker.models import ALBServiceInstance
@@ -134,7 +134,7 @@ def test_migration_pipeline(
     subtest_provision_adds_certificate_to_alb(tasks, alb)
     subtest_provision_provisions_ALIAS_records(tasks, route53, instance_model)
     subtest_provision_waits_for_route53_changes(tasks, route53, instance_model)
-    subtest_removes_certificate_from_alb(
+    subtest_removes_previous_certificate_from_alb(
         tasks, alb, "listener-arn-0", "certificate_arn"
     )
     subtest_renewal_removes_certificate_from_iam(tasks, iam_govcloud)

--- a/tests/integration/test_route53.py
+++ b/tests/integration/test_route53.py
@@ -108,6 +108,9 @@ def test_route53_create_health_checks_updated_cdn_instance(
     operation_id,
     route53,
 ):
+    # Create a CDN instance manually to simulate an instance that
+    # was created in the database before the route53_health_checks
+    # column existed
     create_cdn_instance_statement = insert(CDNServiceInstance).values(
         id=service_instance_id,
         domain_names=["example.com"],

--- a/tests/integration/test_route53.py
+++ b/tests/integration/test_route53.py
@@ -5,6 +5,7 @@ from broker.tasks.route53 import (
     create_new_health_checks,
     delete_unused_health_checks,
     delete_health_checks,
+    _create_health_checks,
 )
 from broker.models import CDNDedicatedWAFServiceInstance, Operation
 

--- a/tests/integration/test_shield.py
+++ b/tests/integration/test_shield.py
@@ -94,6 +94,45 @@ def test_shield_associate_health_check(
     assert operation.step_description == "Associating health check with Shield"
 
 
+def test_shield_associate_health_check_unmigrated_cdn_instance(
+    clean_db,
+    protection_id,
+    protection,
+    service_instance_id,
+    shield,
+    unmigrated_cdn_service_instance_operation_id,
+):
+    operation = clean_db.session.get(
+        Operation, unmigrated_cdn_service_instance_operation_id
+    )
+    service_instance = operation.service_instance
+
+    service_instance.route53_health_checks = [
+        {"domain_name": "example.com", "health_check_id": "example.com ID"},
+        {"domain_name": "foo.com", "health_check_id": "foo.com ID"},
+    ]
+    clean_db.session.add(service_instance)
+    clean_db.session.commit()
+    clean_db.session.expunge_all()
+
+    shield.expect_list_protections([protection])
+    shield.expect_associate_health_check(protection_id, "example.com ID")
+
+    associate_health_check.call_local(unmigrated_cdn_service_instance_operation_id)
+
+    shield.assert_no_pending_responses()
+
+    clean_db.session.expunge_all()
+    service_instance = clean_db.session.get(
+        CDNDedicatedWAFServiceInstance, service_instance_id
+    )
+    assert service_instance.shield_associated_health_check == {
+        "domain_name": "example.com",
+        "health_check_id": "example.com ID",
+        "protection_id": protection_id,
+    }
+
+
 def test_shield_update_no_change_associated_health_check(
     clean_db, protection_id, service_instance_id, service_instance, operation_id, shield
 ):

--- a/tests/lib/alb/update.py
+++ b/tests/lib/alb/update.py
@@ -53,7 +53,9 @@ def subtest_update_noop(client, instance_model):
     assert client.response.status_code == 200
 
 
-def subtest_removes_certificate_from_alb(tasks, alb, listener_arn, certificate_arn):
+def subtest_removes_previous_certificate_from_alb(
+    tasks, alb, listener_arn, certificate_arn
+):
     alb.expect_remove_certificate_from_listener(
         listener_arn,
         certificate_arn,

--- a/tests/lib/cdn/instances.py
+++ b/tests/lib/cdn/instances.py
@@ -1,0 +1,34 @@
+import pytest
+from sqlalchemy import insert
+
+from broker.models import CDNServiceInstance, Operation
+
+
+@pytest.fixture
+def unmigrated_cdn_service_instance_operation_id(
+    clean_db, client, service_instance_id, cloudfront_distribution_arn
+):
+    # Create a CDN instance manually to simulate an instance that
+    # was created in the database before the new columns for the
+    # cdn_dedicated_waf_service_instance were added
+    create_cdn_instance_statement = insert(CDNServiceInstance).values(
+        id=service_instance_id,
+        domain_names=["example.com"],
+        domain_internal="fake1234.cloudfront.net",
+        route53_alias_hosted_zone="Z2FDTNDATAQYW2",
+        origin_protocol_policy="https-only",
+        forwarded_headers=["HOST"],
+        route53_health_checks=None,
+        dedicated_waf_web_acl_arn=None,
+        dedicated_waf_web_acl_id=None,
+        dedicated_waf_web_acl_name=None,
+        shield_associated_health_check=None,
+        cloudwatch_health_check_alarms=None,
+        cloudfront_distribution_arn=cloudfront_distribution_arn,
+        instance_type="cdn_service_instance",
+    )
+    clean_db.session.execute(create_cdn_instance_statement)
+
+    client.update_cdn_to_cdn_dedicated_waf_instance(service_instance_id)
+    operation_id = client.response.json["operation"]
+    return operation_id


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fix error observed in logs during `create_health_checks` task when upgrading CDN to CDN with dedicated WAF instances
- Fix other integration test failures

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing bugs
