### PR TITLE
update time resource to use hardened image

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -870,3 +870,12 @@ resource_types:
     repository: cf-resource
     aws_region: us-gov-west-1
     tag: latest
+
+- name: time
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: time-resource
+    aws_region: us-gov-west-1
+    tag: latest


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates the time resource to use the hardened image

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Last image that needs to be updated for this pipeline
