### PR TITLE
Fix idempotency

### DIFF
--- a/broker/pipelines/cdn_dedicated_waf.py
+++ b/broker/pipelines/cdn_dedicated_waf.py
@@ -37,7 +37,7 @@ def queue_all_cdn_dedicated_waf_provision_tasks_for_operation(
         .then(cloudfront.wait_for_distribution, operation_id, **correlation)
         .then(route53.create_ALIAS_records, operation_id, **correlation)
         .then(route53.wait_for_changes, operation_id, **correlation)
-        .then(route53.create_health_checks, operation_id, **correlation)
+        .then(route53.create_new_health_checks, operation_id, **correlation)
         .then(shield.associate_health_check, operation_id, **correlation)
         .then(cloudwatch.create_health_check_alarms, operation_id, **correlation)
         .then(update_operations.provision, operation_id, **correlation)

--- a/broker/pipelines/plan_updates.py
+++ b/broker/pipelines/plan_updates.py
@@ -57,7 +57,7 @@ def queue_all_cdn_to_cdn_dedicated_waf_update_tasks_for_operation(
         .then(route53.create_ALIAS_records, operation_id, **correlation)
         .then(route53.wait_for_changes, operation_id, **correlation)
         .then(iam.delete_previous_server_certificate, operation_id, **correlation)
-        .then(route53.create_health_checks, operation_id, **correlation)
+        .then(route53.create_new_health_checks, operation_id, **correlation)
         .then(shield.associate_health_check, operation_id, **correlation)
         .then(cloudwatch.create_health_check_alarms, operation_id, **correlation)
         .then(update_operations.update_complete, operation_id, **correlation)

--- a/broker/tasks/cloudwatch.py
+++ b/broker/tasks/cloudwatch.py
@@ -59,9 +59,12 @@ def update_health_check_alarms(operation_id: int, **kwargs):
         health_check["health_check_id"]
         for health_check in service_instance.route53_health_checks
     ]
+    if service_instance.cloudwatch_health_check_alarms == None:
+        existing_health_check_alarms = []
+    else:
+        existing_health_check_alarms = service_instance.cloudwatch_health_check_alarms
     existing_cloudwatch_alarm_health_check_ids = [
-        health_check["health_check_id"]
-        for health_check in service_instance.cloudwatch_health_check_alarms
+        health_check["health_check_id"] for health_check in existing_health_check_alarms
     ]
 
     # IF a health check ID for a Cloudwatch alarm
@@ -69,7 +72,7 @@ def update_health_check_alarms(operation_id: int, **kwargs):
     # THEN the Cloudwatch alarm for the health check ID(s) should be DELETED
     health_checks_alarm_names_to_delete = [
         health_check_alarm["alarm_name"]
-        for health_check_alarm in service_instance.cloudwatch_health_check_alarms
+        for health_check_alarm in existing_health_check_alarms
         if health_check_alarm["health_check_id"]
         not in existing_route53_health_check_ids
     ]

--- a/tests/integration/cdn_dedicated_waf/test_cdn_dedicated_waf_provisioning.py
+++ b/tests/integration/cdn_dedicated_waf/test_cdn_dedicated_waf_provisioning.py
@@ -163,7 +163,7 @@ def test_provision_happy_path(
     )
     subtest_provision_creates_health_checks(tasks, route53, instance_model)
     check_last_operation_description(
-        client, "4321", operation_id, "Creating health checks"
+        client, "4321", operation_id, "Creating new health checks"
     )
     subtest_provision_associate_health_check(tasks, shield, instance_model)
     check_last_operation_description(

--- a/tests/integration/plan_updates/test_cdn_update_to_cdn_dedicated_waf.py
+++ b/tests/integration/plan_updates/test_cdn_update_to_cdn_dedicated_waf.py
@@ -191,7 +191,7 @@ def test_update_plan_and_domains(
         tasks, route53, instance_model, expected_domain_names=["bar.com", "foo.com"]
     )
     check_last_operation_description(
-        client, "4321", operation_id, "Creating health checks"
+        client, "4321", operation_id, "Creating new health checks"
     )
     subtest_provision_associate_health_check(
         tasks, shield, instance_model, expected_domain_name="bar.com"


### PR DESCRIPTION
## Changes proposed in this pull request:

- [delete route53.create_health_checks method and replace with route53.create_new_health_checks & refactor tests](https://github.com/cloud-gov/external-domain-broker/commit/48a26aced57ff69e6412818fc32cf9aa8b970267) 
- [update update_health_check_alarms to handle missing cloudwatch_health_check_alarms property on service instance](https://github.com/cloud-gov/external-domain-broker/commit/1d8694d786fb4d31f99563792160406a35c00771) 
- [add test for update_health_check_alarms idempotency](https://github.com/cloud-gov/external-domain-broker/commit/63c9f38bb0f1c70f30af06bbb444e9a8e8249f0c)

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing bugs with broker idempotency
