### PR TITLE
Add cron pipelines dedicated WAF

### DIFF
--- a/broker/api.py
+++ b/broker/api.py
@@ -37,6 +37,7 @@ from broker.models import (
     ServiceInstance,
     change_instance_type,
     Certificate,
+    ServiceInstanceTypes,
 )
 from broker.pipelines.alb import (
     queue_all_alb_provision_tasks_for_operation,
@@ -326,7 +327,7 @@ class API(ServiceBroker):
             instance.new_certificate = instance.current_certificate
 
         noop = not has_domain_updates
-        if instance.instance_type == "cdn_service_instance":
+        if instance.instance_type == ServiceInstanceTypes.CDN.value:
             noop = False
 
             if details.plan_id == CDN_PLAN_ID:
@@ -347,7 +348,7 @@ class API(ServiceBroker):
                 db.session.refresh(instance)
             else:
                 raise ClientError("Updating service plan is not supported")
-        elif instance.instance_type == "cdn_dedicated_waf_service_instance":
+        elif instance.instance_type == ServiceInstanceTypes.CDN_DEDICATED_WAF.value:
             noop = False
 
             if details.plan_id != CDN_DEDICATED_WAF_PLAN_ID:
@@ -356,7 +357,7 @@ class API(ServiceBroker):
             instance = update_cdn_instance(params, instance)
 
             queue = queue_all_cdn_dedicated_waf_update_tasks_for_operation
-        elif instance.instance_type == "alb_service_instance":
+        elif instance.instance_type == ServiceInstanceTypes.ALB.value:
             if details.plan_id == ALB_PLAN_ID:
                 queue = queue_all_alb_update_tasks_for_operation
             elif details.plan_id == DEDICATED_ALB_PLAN_ID:
@@ -372,11 +373,11 @@ class API(ServiceBroker):
                 noop = False
             else:
                 raise ClientError("Updating service plan is not supported")
-        elif instance.instance_type == "dedicated_alb_service_instance":
+        elif instance.instance_type == ServiceInstanceTypes.DEDICATED_ALB.value:
             if details.plan_id != DEDICATED_ALB_PLAN_ID:
                 raise ClientError("Updating service plan is not supported")
             queue = queue_all_dedicated_alb_update_tasks_for_operation
-        elif instance.instance_type == "migration_service_instance":
+        elif instance.instance_type == ServiceInstanceTypes.MIGRATION.value:
             if details.plan_id == CDN_PLAN_ID:
                 noop = False
                 validate_migration_to_cdn_params(params)

--- a/broker/lib/cdn.py
+++ b/broker/lib/cdn.py
@@ -1,5 +1,8 @@
+from broker.models import ServiceInstanceTypes
+
+
 def is_cdn_instance(service_instance):
     return service_instance.instance_type in [
-        "cdn_service_instance",
-        "cdn_dedicated_waf_service_instance",
+        ServiceInstanceTypes.CDN.value,
+        ServiceInstanceTypes.CDN_DEDICATED_WAF.value,
     ]

--- a/broker/models.py
+++ b/broker/models.py
@@ -24,6 +24,7 @@ class ServiceInstanceTypes(Enum):
     CDN = "cdn_service_instance"
     CDN_DEDICATED_WAF = "cdn_dedicated_waf_service_instance"
     DEDICATED_ALB = "dedicated_alb_service_instance"
+    MIGRATION = "migration_service_instance"
 
 
 def db_encryption_key():
@@ -241,7 +242,7 @@ class DedicatedALBServiceInstance(AbstractALBServiceInstance):
 
 
 class MigrationServiceInstance(ServiceInstance):
-    __mapper_args__ = {"polymorphic_identity": "migration_service_instance"}
+    __mapper_args__ = {"polymorphic_identity": ServiceInstanceTypes.MIGRATION.value}
 
     @classmethod
     def update_targets(self) -> List[type]:

--- a/broker/models.py
+++ b/broker/models.py
@@ -19,6 +19,13 @@ from broker.extensions import config, db
 logger = logging.getLogger(__name__)
 
 
+class ServiceInstanceTypes(Enum):
+    ALB = "alb_service_instance"
+    CDN = "cdn_service_instance"
+    CDN_DEDICATED_WAF = "cdn_dedicated_waf_service_instance"
+    DEDICATED_ALB = "dedicated_alb_service_instance"
+
+
 def db_encryption_key():
     return config.DATABASE_ENCRYPTION_KEY
 
@@ -167,7 +174,7 @@ class CDNServiceInstance(ServiceInstance):
     error_responses = mapped_column(postgresql.JSONB, default=[])
     origin_protocol_policy = mapped_column(db.String)
 
-    __mapper_args__ = {"polymorphic_identity": "cdn_service_instance"}
+    __mapper_args__ = {"polymorphic_identity": ServiceInstanceTypes.CDN.value}
 
     @classmethod
     def update_targets(self) -> List[type]:
@@ -185,7 +192,9 @@ class CDNDedicatedWAFServiceInstance(CDNServiceInstance):
     shield_associated_health_check = mapped_column(postgresql.JSONB, default={})
     cloudwatch_health_check_alarms = mapped_column(postgresql.JSONB, default=[])
 
-    __mapper_args__ = {"polymorphic_identity": "cdn_dedicated_waf_service_instance"}
+    __mapper_args__ = {
+        "polymorphic_identity": ServiceInstanceTypes.CDN_DEDICATED_WAF.value
+    }
 
     def __repr__(self):
         return f"<CDNDedicatedWAFServiceInstance {self.id} {self.domain_names}>"
@@ -208,7 +217,7 @@ class AbstractALBServiceInstance(ServiceInstance):
 
 class ALBServiceInstance(AbstractALBServiceInstance):
 
-    __mapper_args__ = {"polymorphic_identity": "alb_service_instance"}
+    __mapper_args__ = {"polymorphic_identity": ServiceInstanceTypes.ALB.value}
 
     @classmethod
     def update_targets(self) -> List[type]:
@@ -221,7 +230,7 @@ class ALBServiceInstance(AbstractALBServiceInstance):
 class DedicatedALBServiceInstance(AbstractALBServiceInstance):
     org_id = mapped_column(db.String)
 
-    __mapper_args__ = {"polymorphic_identity": "dedicated_alb_service_instance"}
+    __mapper_args__ = {"polymorphic_identity": ServiceInstanceTypes.DEDICATED_ALB.value}
 
     @classmethod
     def update_targets(self) -> List[type]:

--- a/broker/tasks/cron.py
+++ b/broker/tasks/cron.py
@@ -83,7 +83,7 @@ def scan_for_expiring_certs():
                 cdn_renewals.append(renewal)
             elif instance.instance_type == ServiceInstanceTypes.ALB.value:
                 alb_renewals.append(renewal)
-            elif instance.instance_type == ServiceInstanceTypes.DEDICATED_ALB.evalue:
+            elif instance.instance_type == ServiceInstanceTypes.DEDICATED_ALB.value:
                 dedicated_alb_renewals.append(renewal)
         db.session.commit()
         for renewal in cdn_renewals:

--- a/broker/tasks/cron.py
+++ b/broker/tasks/cron.py
@@ -170,3 +170,5 @@ def reschedule_operation(operation_id):
         queue(operation.id)
     else:
         queue(operation.id, "Recovered operation")
+    # this line is only used for testing
+    return queue

--- a/broker/tasks/cron.py
+++ b/broker/tasks/cron.py
@@ -20,6 +20,11 @@ from broker.pipelines.cdn import (
     queue_all_cdn_update_tasks_for_operation,
     queue_all_cdn_renewal_tasks_for_operation,
 )
+from broker.pipelines.cdn_dedicated_waf import (
+    queue_all_cdn_dedicated_waf_deprovision_tasks_for_operation,
+    queue_all_cdn_dedicated_waf_provision_tasks_for_operation,
+    queue_all_cdn_dedicated_waf_update_tasks_for_operation,
+)
 from broker.pipelines.dedicated_alb import (
     queue_all_dedicated_alb_renewal_tasks_for_operation,
     queue_all_dedicated_alb_provision_tasks_for_operation,
@@ -138,10 +143,17 @@ def reschedule_operation(operation_id):
         actions.RENEW.value: queue_all_dedicated_alb_renewal_tasks_for_operation,
         actions.UPDATE.value: queue_all_dedicated_alb_update_tasks_for_operation,
     }
+    cdn_dedicated_waf_queues = {
+        actions.DEPROVISION.value: queue_all_cdn_dedicated_waf_deprovision_tasks_for_operation,
+        actions.PROVISION.value: queue_all_cdn_dedicated_waf_provision_tasks_for_operation,
+        actions.RENEW.value: queue_all_cdn_renewal_tasks_for_operation,
+        actions.UPDATE.value: queue_all_cdn_dedicated_waf_update_tasks_for_operation,
+    }
     queues = {
         "cdn_service_instance": cdn_queues,
         "alb_service_instance": alb_queues,
         "dedicated_alb_service_instance": dedicated_alb_queues,
+        "cdn_dedicated_waf_service_instance": cdn_dedicated_waf_queues,
     }
     queue = queues[service_instance.instance_type].get(operation.action)
     if not queue:

--- a/broker/tasks/cron.py
+++ b/broker/tasks/cron.py
@@ -2,11 +2,16 @@ import datetime
 import logging
 
 from huey import crontab
-from sqlalchemy import select
 
 from broker.extensions import db, config
 from broker.lib.cdn import is_cdn_instance
-from broker.models import Certificate, Operation, DedicatedALBListener, ServiceInstance
+from broker.models import (
+    Certificate,
+    Operation,
+    DedicatedALBListener,
+    ServiceInstance,
+    ServiceInstanceTypes,
+)
 from broker.tasks import huey
 from broker.pipelines.alb import (
     queue_all_alb_deprovision_tasks_for_operation,
@@ -76,9 +81,9 @@ def scan_for_expiring_certs():
             db.session.add(renewal)
             if is_cdn_instance(instance):
                 cdn_renewals.append(renewal)
-            elif instance.instance_type == "alb_service_instance":
+            elif instance.instance_type == ServiceInstanceTypes.ALB.value:
                 alb_renewals.append(renewal)
-            elif instance.instance_type == "dedicated_alb_service_instance":
+            elif instance.instance_type == ServiceInstanceTypes.DEDICATED_ALB.evalue:
                 dedicated_alb_renewals.append(renewal)
         db.session.commit()
         for renewal in cdn_renewals:
@@ -149,12 +154,13 @@ def reschedule_operation(operation_id):
         actions.RENEW.value: queue_all_cdn_renewal_tasks_for_operation,
         actions.UPDATE.value: queue_all_cdn_dedicated_waf_update_tasks_for_operation,
     }
-    queues = {
-        "cdn_service_instance": cdn_queues,
-        "alb_service_instance": alb_queues,
-        "dedicated_alb_service_instance": dedicated_alb_queues,
-        "cdn_dedicated_waf_service_instance": cdn_dedicated_waf_queues,
-    }
+    queues = {}
+
+    queues[ServiceInstanceTypes.CDN.value] = cdn_queues
+    queues[ServiceInstanceTypes.ALB.value] = alb_queues
+    queues[ServiceInstanceTypes.DEDICATED_ALB.value] = dedicated_alb_queues
+    queues[ServiceInstanceTypes.CDN_DEDICATED_WAF.value] = cdn_dedicated_waf_queues
+
     queue = queues[service_instance.instance_type].get(operation.action)
     if not queue:
         raise RuntimeError(

--- a/broker/tasks/huey.py
+++ b/broker/tasks/huey.py
@@ -65,6 +65,10 @@ def mark_operation_failed(signal, task, exc=None):
     with huey.flask_app.app_context():
         try:
             operation = db.session.get(Operation, args[0])
+        except IndexError as e:
+            logger.exception(
+                msg=f"exception loading operation for args {args}", exc_info=e
+            )
         except BaseException as e:
             logger.exception(
                 msg=f"exception loading operation for args {args}", exc_info=e

--- a/broker/tasks/huey.py
+++ b/broker/tasks/huey.py
@@ -65,11 +65,7 @@ def mark_operation_failed(signal, task, exc=None):
     with huey.flask_app.app_context():
         try:
             operation = db.session.get(Operation, args[0])
-        except IndexError as e:
-            logger.exception(
-                msg=f"exception loading operation for args {args}", exc_info=e
-            )
-        except BaseException as e:
+        except (BaseException, IndexError) as e:
             logger.exception(
                 msg=f"exception loading operation for args {args}", exc_info=e
             )

--- a/dev
+++ b/dev
@@ -23,7 +23,7 @@ main() {
     docker-compose-up | dkc-up)
       source_env_vars
       cd docker
-      docker-compose up
+      docker compose up
       ;;
     serve)
       build_image

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ from tests.lib.fake_cloudwatch import cloudwatch_commercial  # noqa F401
 from tests.lib.simple_regex import simple_regex  # noqa F401
 from tests.lib.cdn.instances import (
     unmigrated_cdn_service_instance_operation_id,
-    unmigrated_cdn_dedicated_waf_operation_id,
+    unmigrated_cdn_dedicated_waf_service_instance_operation_id,
 )  # noqa F401
 from tests.lib.dns import dns  # noqa 401
 from tests.lib.tasks import tasks  # noqa 401

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ from tests.lib.fake_cloudwatch import cloudwatch_commercial  # noqa F401
 from tests.lib.simple_regex import simple_regex  # noqa F401
 from tests.lib.cdn.instances import (
     unmigrated_cdn_service_instance_operation_id,
+    unmigrated_cdn_dedicated_waf_operation_id,
 )  # noqa F401
 from tests.lib.dns import dns  # noqa 401
 from tests.lib.tasks import tasks  # noqa 401

--- a/tests/integration/cdn_dedicated_waf/test_cdn_dedicated_waf_renewals.py
+++ b/tests/integration/cdn_dedicated_waf/test_cdn_dedicated_waf_renewals.py
@@ -1,0 +1,191 @@
+from datetime import datetime, timedelta, date
+
+import pytest
+
+from broker.extensions import db
+from broker.models import Operation, CDNDedicatedWAFServiceInstance
+from broker.tasks.cron import scan_for_expiring_certs
+from broker.tasks.huey import huey
+from broker.tasks.letsencrypt import create_user, generate_private_key
+
+from tests.lib.provision import (
+    subtest_provision_initiates_LE_challenge,
+    subtest_provision_updates_TXT_records,
+    subtest_provision_waits_for_route53_changes,
+    subtest_provision_answers_challenges,
+    subtest_provision_marks_operation_as_succeeded,
+)
+from tests.lib.cdn.provision import (
+    subtest_provision_uploads_certificate_to_iam,
+)
+from tests.lib.cdn.update import (
+    subtest_update_creates_private_key_and_csr,
+)
+from tests.lib.factories import (
+    CDNDedicatedWAFServiceInstanceFactory,
+    CertificateFactory,
+    OperationFactory,
+)
+from tests.lib.fake_cloudfront import FakeCloudFront
+
+
+@pytest.fixture
+def cdn_instance_needing_renewal(clean_db, tasks):
+    """
+    create a cdn service instance that needs renewal.
+    This includes walking it through the first few ACME steps to create a user so we can reuse that user.
+    """
+    renew_service_instance = CDNDedicatedWAFServiceInstanceFactory.create(
+        id="4321",
+        domain_names=["example.com", "foo.com"],
+        domain_internal="fake1234.cloudfront.net",
+        route53_alias_hosted_zone="Z2FDTNDATAQYW2",
+        cloudfront_distribution_id="FakeDistributionId",
+        cloudfront_origin_hostname="origin_hostname",
+    )
+
+    current_cert = CertificateFactory.create(
+        id=1001,
+        service_instance=renew_service_instance,
+        expires_at=datetime.now() + timedelta(days=29),
+        iam_server_certificate_id="certificate_id",
+        iam_server_certificate_name="certificate_name",
+        iam_server_certificate_arn="certificate_arn",
+        private_key_pem="SOMEPRIVATEKEY",
+    )
+    renew_service_instance.current_certificate = current_cert
+
+    db.session.add(renew_service_instance)
+    db.session.add(current_cert)
+    db.session.commit()
+    db.session.expunge_all()
+
+    # create an operation, since that's what our task pipelines know to look for
+    operation = OperationFactory.create(service_instance=renew_service_instance)
+    db.session.refresh(operation)
+    db.session.commit()
+
+    huey.enqueue(create_user.s(operation.id))
+    tasks.run_queued_tasks_and_enqueue_dependents()
+    huey.enqueue(generate_private_key.s(operation.id))
+    tasks.run_queued_tasks_and_enqueue_dependents()
+
+    # delete the operation to simplify checks on operations later
+    db.session.delete(operation)
+    db.session.commit()
+    return renew_service_instance
+
+
+def test_scan_for_expiring_certs_cdn_happy_path(
+    clean_db,
+    cdn_instance_needing_renewal,
+    tasks,
+    route53,
+    dns,
+    iam_commercial,
+    simple_regex,
+    cloudfront,
+):
+
+    no_renew_service_instance = CDNDedicatedWAFServiceInstanceFactory.create(
+        id="1234",
+        domain_names=["example.org", "foo.org"],
+        domain_internal="fake1234.cloudfront.net",
+        route53_alias_hosted_zone="Z2FDTNDATAQYW2",
+        cloudfront_distribution_id="FakeDistributionId",
+        cloudfront_origin_hostname="origin_hostname",
+        cloudfront_origin_path="origin_path",
+    )
+    no_renew_cert = CertificateFactory.create(
+        id=1002,
+        service_instance=no_renew_service_instance,
+        expires_at=datetime.now() + timedelta(days=31),
+        private_key_pem="SOMEPRIVATEKEY",
+        iam_server_certificate_id="certificate_id",
+        iam_server_certificate_name="certificate_name",
+        iam_server_certificate_arn="certificate_arn",
+    )
+    no_renew_service_instance.current_certificate = no_renew_cert
+
+    db.session.add(no_renew_service_instance)
+    db.session.add(no_renew_cert)
+    db.session.commit()
+    db.session.expunge_all()
+    dns.add_cname("_acme-challenge.example.com")
+    dns.add_cname("_acme-challenge.foo.com")
+
+    instance_model = CDNDedicatedWAFServiceInstance
+
+    subtest_queues_tasks()
+    subtest_update_creates_private_key_and_csr(tasks, instance_model)
+    subtest_provision_initiates_LE_challenge(tasks, instance_model)
+    subtest_provision_updates_TXT_records(tasks, route53, instance_model)
+    subtest_provision_waits_for_route53_changes(tasks, route53, instance_model)
+    subtest_provision_answers_challenges(tasks, dns, instance_model)
+    subtest_renew_retrieves_certificate(tasks)
+    subtest_provision_uploads_certificate_to_iam(
+        tasks, iam_commercial, simple_regex, instance_model
+    )
+    subtest_updates_certificate_in_cloudfront(tasks, cloudfront)
+    subtest_renewal_removes_certificate_from_iam(tasks, iam_commercial)
+    subtest_provision_marks_operation_as_succeeded(tasks, instance_model)
+
+
+def subtest_queues_tasks():
+    assert scan_for_expiring_certs.call_local() == ["4321"]
+    service_instance = db.session.get(CDNDedicatedWAFServiceInstance, "4321")
+
+    assert len(list(service_instance.operations)) == 1
+    operation = service_instance.operations[0]
+    assert operation.action == Operation.Actions.RENEW.value
+    assert len(huey.pending()) == 1
+
+
+def subtest_updates_certificate_in_cloudfront(tasks, cloudfront: FakeCloudFront):
+    cloudfront.expect_get_distribution_config(
+        caller_reference="4321",
+        domains=["example.com", "foo.com"],
+        certificate_id="certificate_id",
+        origin_hostname="origin_hostname",
+        origin_path="origin_path",
+        distribution_id="FakeDistributionId",
+        bucket_prefix="4321/",
+    )
+    cloudfront.expect_update_distribution(
+        caller_reference="4321",
+        domains=["example.com", "foo.com"],
+        certificate_id="FAKE_CERT_ID_XXXXXXXX",
+        origin_hostname="origin_hostname",
+        origin_path="origin_path",
+        distribution_id="FakeDistributionId",
+        distribution_hostname="fake1234.cloudfront.net",
+        bucket_prefix="4321/",
+    )
+
+    tasks.run_queued_tasks_and_enqueue_dependents()
+    cloudfront.assert_no_pending_responses()
+
+
+def subtest_renew_retrieves_certificate(tasks):
+    tasks.run_queued_tasks_and_enqueue_dependents()
+
+    db.session.expunge_all()
+    service_instance = db.session.get(CDNDedicatedWAFServiceInstance, "4321")
+
+    assert len(service_instance.certificates) == 2
+    certificate = service_instance.new_certificate
+
+    assert certificate.fullchain_pem.count("BEGIN CERTIFICATE") == 1
+    assert certificate.leaf_pem.count("BEGIN CERTIFICATE") == 1
+    assert certificate.expires_at is not None
+
+
+def subtest_renewal_removes_certificate_from_iam(tasks, iam_govcloud):
+    iam_govcloud.expect_get_server_certificate("certificate_name")
+    iam_govcloud.expects_delete_server_certificate("certificate_name")
+
+    tasks.run_queued_tasks_and_enqueue_dependents()
+
+    iam_govcloud.assert_no_pending_responses()
+    instance = db.session.get(CDNDedicatedWAFServiceInstance, "4321")
+    assert len(instance.certificates) == 1

--- a/tests/integration/plan_updates/test_cdn_update_to_cdn_dedicated_waf.py
+++ b/tests/integration/plan_updates/test_cdn_update_to_cdn_dedicated_waf.py
@@ -6,6 +6,7 @@ from broker.models import (
     CDNDedicatedWAFServiceInstance,
     Operation,
     ServiceInstance,
+    ServiceInstanceTypes,
 )
 
 from tests.lib.client import check_last_operation_description
@@ -263,10 +264,10 @@ def subtest_update_creates_update_plan_and_domains_operation(
 def subtest_is_cdn_instance(service_instance_id="4321"):
     db.session.expunge_all()
     instance = db.session.get(ServiceInstance, service_instance_id)
-    assert instance.instance_type == "cdn_service_instance"
+    assert instance.instance_type == ServiceInstanceTypes.CDN.value
 
 
 def subtest_is_cdn_dedicated_waf_instance(service_instance_id="4321"):
     db.session.expunge_all()
     instance = db.session.get(ServiceInstance, service_instance_id)
-    assert instance.instance_type == "cdn_dedicated_waf_service_instance"
+    assert instance.instance_type == ServiceInstanceTypes.CDN_DEDICATED_WAF.value

--- a/tests/integration/test_cloudwatch.py
+++ b/tests/integration/test_cloudwatch.py
@@ -399,11 +399,6 @@ def test_update_health_check_alarms_idempotent(
 
     clean_db.session.expunge_all()
 
-    operation = clean_db.session.get(Operation, operation_id)
-    assert (
-        operation.step_description
-        == "Updating Cloudwatch alarms for Route53 health checks"
-    )
     service_instance = clean_db.session.get(
         CDNDedicatedWAFServiceInstance,
         service_instance_id,
@@ -415,6 +410,82 @@ def test_update_health_check_alarms_idempotent(
     update_health_check_alarms.call_local(operation_id)
     # asserts that all the mocked calls above were made
     cloudwatch_commercial.assert_no_pending_responses()
+
+
+def test_create_health_check_alarms_unmigrated_instance(
+    clean_db,
+    service_instance_id,
+    unmigrated_cdn_dedicated_waf_operation_id,
+    cloudwatch_commercial,
+):
+    operation = clean_db.session.get(
+        Operation, unmigrated_cdn_dedicated_waf_operation_id
+    )
+    service_instance = operation.service_instance
+    tags = service_instance.tags
+
+    expect_create_health_check_id = "bar.com ID"
+    expected_health_check_alarms = [
+        {
+            "health_check_id": "example.com ID",
+            "alarm_name": _get_alarm_name("example.com ID"),
+        },
+        {
+            "health_check_id": expect_create_health_check_id,
+            "alarm_name": _get_alarm_name(expect_create_health_check_id),
+        },
+    ]
+
+    # Simulate an update to the domains and health checks
+    service_instance.domain_names = ["example.com", "bar.com"]
+    service_instance.route53_health_checks = [
+        {
+            "domain_name": "example.com",
+            "health_check_id": "example.com ID",
+        },
+        {
+            "domain_name": "bar.com",
+            "health_check_id": "bar.com ID",
+        },
+    ]
+
+    clean_db.session.add(service_instance)
+    clean_db.session.commit()
+    clean_db.session.expunge_all()
+
+    cloudwatch_commercial.expect_put_metric_alarm(
+        "example.com ID",
+        _get_alarm_name("example.com ID"),
+        tags,
+    )
+    cloudwatch_commercial.expect_describe_alarms(
+        _get_alarm_name("example.com ID"),
+        [{"AlarmArn": "example.com ID ARN"}],
+    )
+    cloudwatch_commercial.expect_put_metric_alarm(
+        expect_create_health_check_id,
+        _get_alarm_name(expect_create_health_check_id),
+        tags,
+    )
+    cloudwatch_commercial.expect_describe_alarms(
+        _get_alarm_name(expect_create_health_check_id),
+        [{"AlarmArn": f"{expect_create_health_check_id} ARN"}],
+    )
+
+    update_health_check_alarms.call_local(unmigrated_cdn_dedicated_waf_operation_id)
+
+    # asserts that all the mocked calls above were made
+    cloudwatch_commercial.assert_no_pending_responses()
+
+    clean_db.session.expunge_all()
+
+    service_instance = clean_db.session.get(
+        CDNDedicatedWAFServiceInstance,
+        service_instance_id,
+    )
+    assert (
+        service_instance.cloudwatch_health_check_alarms == expected_health_check_alarms
+    )
 
 
 def test_delete_health_check_alarms(

--- a/tests/integration/test_cloudwatch.py
+++ b/tests/integration/test_cloudwatch.py
@@ -412,7 +412,7 @@ def test_update_health_check_alarms_idempotent(
     cloudwatch_commercial.assert_no_pending_responses()
 
 
-def test_create_health_check_alarms_unmigrated_instance(
+def test_update_health_check_alarms_unmigrated_instance(
     clean_db,
     service_instance_id,
     unmigrated_cdn_dedicated_waf_service_instance_operation_id,

--- a/tests/integration/test_cloudwatch.py
+++ b/tests/integration/test_cloudwatch.py
@@ -415,11 +415,11 @@ def test_update_health_check_alarms_idempotent(
 def test_create_health_check_alarms_unmigrated_instance(
     clean_db,
     service_instance_id,
-    unmigrated_cdn_dedicated_waf_operation_id,
+    unmigrated_cdn_dedicated_waf_service_instance_operation_id,
     cloudwatch_commercial,
 ):
     operation = clean_db.session.get(
-        Operation, unmigrated_cdn_dedicated_waf_operation_id
+        Operation, unmigrated_cdn_dedicated_waf_service_instance_operation_id
     )
     service_instance = operation.service_instance
     tags = service_instance.tags
@@ -472,7 +472,9 @@ def test_create_health_check_alarms_unmigrated_instance(
         [{"AlarmArn": f"{expect_create_health_check_id} ARN"}],
     )
 
-    update_health_check_alarms.call_local(unmigrated_cdn_dedicated_waf_operation_id)
+    update_health_check_alarms.call_local(
+        unmigrated_cdn_dedicated_waf_service_instance_operation_id
+    )
 
     # asserts that all the mocked calls above were made
     cloudwatch_commercial.assert_no_pending_responses()

--- a/tests/integration/test_cron.py
+++ b/tests/integration/test_cron.py
@@ -1,0 +1,41 @@
+import pytest
+
+from broker.models import ServiceInstanceTypes
+from broker.tasks.cron import reschedule_operation
+
+from tests.lib.factories import (
+    ALBServiceInstanceFactory,
+    CDNServiceInstanceFactory,
+    CDNDedicatedWAFServiceInstanceFactory,
+    DedicatedALBServiceInstanceFactory,
+    OperationFactory,
+)
+
+
+@pytest.fixture
+def service_instance(clean_db, operation_id, service_instance_id, instance_factory):
+    service_instance = instance_factory.create(
+        id=service_instance_id,
+        domain_names=["example.com", "foo.com"],
+        domain_internal="fake1234.cloudfront.net",
+        route53_alias_hosted_zone="Z2FDTNDATAQYW2",
+    )
+    clean_db.session.add(service_instance)
+    clean_db.session.commit()
+    clean_db.session.expunge_all()
+    OperationFactory.create(id=operation_id, service_instance=service_instance)
+    return service_instance
+
+
+@pytest.mark.parametrize(
+    "instance_factory",
+    [
+        ALBServiceInstanceFactory,
+        CDNServiceInstanceFactory,
+        CDNDedicatedWAFServiceInstanceFactory,
+        DedicatedALBServiceInstanceFactory,
+    ],
+)
+def test_reschedule_operation_for_all_instance_types(service_instance, operation_id):
+    result = reschedule_operation(operation_id)
+    assert result is not None

--- a/tests/lib/cdn/instances.py
+++ b/tests/lib/cdn/instances.py
@@ -1,7 +1,7 @@
 import pytest
 from sqlalchemy import insert
 
-from broker.models import CDNServiceInstance, Operation
+from broker.models import CDNServiceInstance, ServiceInstanceTypes
 
 
 @pytest.fixture
@@ -25,7 +25,7 @@ def unmigrated_cdn_service_instance_operation_id(
         shield_associated_health_check=None,
         cloudwatch_health_check_alarms=None,
         cloudfront_distribution_arn=cloudfront_distribution_arn,
-        instance_type="cdn_service_instance",
+        instance_type=ServiceInstanceTypes.CDN.value,
     )
     clean_db.session.execute(create_cdn_instance_statement)
 

--- a/tests/lib/cdn/instances.py
+++ b/tests/lib/cdn/instances.py
@@ -39,7 +39,7 @@ def unmigrated_cdn_service_instance_operation_id(
 
 
 @pytest.fixture
-def unmigrated_cdn_dedicated_waf_operation_id(
+def unmigrated_cdn_dedicated_waf_service_instance_operation_id(
     clean_db, client, service_instance_id, cloudfront_distribution_arn
 ):
     # Create a CDN instance manually to simulate an instance that

--- a/tests/lib/cdn/instances.py
+++ b/tests/lib/cdn/instances.py
@@ -1,7 +1,11 @@
 import pytest
 from sqlalchemy import insert
 
-from broker.models import CDNServiceInstance, ServiceInstanceTypes
+from broker.models import (
+    CDNServiceInstance,
+    CDNDedicatedWAFServiceInstance,
+    ServiceInstanceTypes,
+)
 
 
 @pytest.fixture
@@ -12,6 +16,36 @@ def unmigrated_cdn_service_instance_operation_id(
     # was created in the database before the new columns for the
     # cdn_dedicated_waf_service_instance were added
     create_cdn_instance_statement = insert(CDNServiceInstance).values(
+        id=service_instance_id,
+        domain_names=["example.com"],
+        domain_internal="fake1234.cloudfront.net",
+        route53_alias_hosted_zone="Z2FDTNDATAQYW2",
+        origin_protocol_policy="https-only",
+        forwarded_headers=["HOST"],
+        route53_health_checks=None,
+        dedicated_waf_web_acl_arn=None,
+        dedicated_waf_web_acl_id=None,
+        dedicated_waf_web_acl_name=None,
+        shield_associated_health_check=None,
+        cloudwatch_health_check_alarms=None,
+        cloudfront_distribution_arn=cloudfront_distribution_arn,
+        instance_type=ServiceInstanceTypes.CDN.value,
+    )
+    clean_db.session.execute(create_cdn_instance_statement)
+
+    client.update_cdn_to_cdn_dedicated_waf_instance(service_instance_id)
+    operation_id = client.response.json["operation"]
+    return operation_id
+
+
+@pytest.fixture
+def unmigrated_cdn_dedicated_waf_operation_id(
+    clean_db, client, service_instance_id, cloudfront_distribution_arn
+):
+    # Create a CDN instance manually to simulate an instance that
+    # was created in the database before the new columns for the
+    # cdn_dedicated_waf_service_instance were added
+    create_cdn_instance_statement = insert(CDNDedicatedWAFServiceInstance).values(
         id=service_instance_id,
         domain_names=["example.com"],
         domain_internal="fake1234.cloudfront.net",


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/private/issues/1098

- Add missing code for restarting stalled pipelines for CDN with dedicated WAF instances
- Update code to use enum for service instance types 
- Catch `IndexError` when restarting operations
- Add integration test for CDN with dedicated WAF renewals

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing bugs
