### PR TITLE
Various fixes

### DIFF
--- a/broker/config.py
+++ b/broker/config.py
@@ -40,7 +40,6 @@ class Config:
         # how long we wait between updating DNS to point to a new ALB and removing the
         # certificate from an old ALB
         self.ALB_OVERLAP_SLEEP_TIME = self.env.int("ALB_OVERLAP_SLEEP_TIME", 900)
-        self.CLOUDFRONT_PROPAGATION_SLEEP_TIME = 60  # Seconds
         self.SQLALCHEMY_TRACK_MODIFICATIONS = False
         self.TESTING = True
         self.DEBUG = True
@@ -284,7 +283,6 @@ class TestConfig(DockerConfig):
         super().__init__()
         self.DNS_PROPAGATION_SLEEP_TIME = 0
         self.ALB_OVERLAP_SLEEP_TIME = 0
-        self.CLOUDFRONT_PROPAGATION_SLEEP_TIME = 0
         self.ACME_POLL_TIMEOUT_IN_SECONDS = 10
         self.AWS_POLL_WAIT_TIME_IN_SECONDS = 0
         self.AWS_POLL_MAX_ATTEMPTS = 10

--- a/broker/tasks/cloudfront.py
+++ b/broker/tasks/cloudfront.py
@@ -227,7 +227,7 @@ def wait_for_distribution_disabled(operation_id: int, **kwargs):
     num_times = 0
     while not distribution_disabled:
         num_times += 1
-        if num_times >= 60:
+        if num_times > config.AWS_POLL_MAX_ATTEMPTS:
             logger.info(
                 "Failed to disable distribution",
                 extra={
@@ -236,7 +236,7 @@ def wait_for_distribution_disabled(operation_id: int, **kwargs):
                 },
             )
             raise RuntimeError("Failed to disable distribution")
-        time.sleep(config.CLOUDFRONT_PROPAGATION_SLEEP_TIME)
+        time.sleep(config.AWS_POLL_WAIT_TIME_IN_SECONDS)
         try:
             status = cloudfront.get_distribution(
                 Id=service_instance.cloudfront_distribution_id

--- a/broker/tasks/cron.py
+++ b/broker/tasks/cron.py
@@ -101,8 +101,8 @@ def scan_for_expiring_certs():
 @huey.huey.periodic_task(crontab(month="*", hour="*", day="*", minute="*/5"))
 def restart_stalled_pipelines():
     with huey.huey.flask_app.app_context():
-        for operation in scan_for_stalled_pipelines():
-            reschedule_operation(operation)
+        for operation_id in scan_for_stalled_pipelines:
+            reschedule_operation(operation_id)
 
 
 @huey.huey.periodic_task(crontab(month="*", hour="*", day="*", minute="*"))

--- a/broker/tasks/route53.py
+++ b/broker/tasks/route53.py
@@ -328,8 +328,14 @@ def delete_health_checks(operation_id: int, **kwargs):
 
     logger.info(f'Deleting health check(s) for "{service_instance.domain_names}"')
 
+    existing_health_checks = service_instance.route53_health_checks
+
+    if existing_health_checks == None:
+        logger.info("No Route53 health checks to delete")
+        return
+
     updated_health_checks = _delete_health_checks(
-        service_instance.route53_health_checks, service_instance.route53_health_checks
+        existing_health_checks, existing_health_checks
     )
 
     service_instance.route53_health_checks = updated_health_checks

--- a/broker/tasks/shield.py
+++ b/broker/tasks/shield.py
@@ -109,7 +109,8 @@ def disassociate_health_check(operation_id: int, **kwargs):
 
     service_instance = operation.service_instance
 
-    if service_instance.shield_associated_health_check == None:
+    shield_associated_health_check = service_instance.shield_associated_health_check
+    if shield_associated_health_check == None:
         logger.info("No health check to disassociate from Shield")
         return
 
@@ -119,7 +120,7 @@ def disassociate_health_check(operation_id: int, **kwargs):
     db.session.commit()
 
     _disassociate_health_check(
-        service_instance.shield_associated_health_check,
+        shield_associated_health_check,
     )
     service_instance.shield_associated_health_check = None
     flag_modified(service_instance, "shield_associated_health_check")

--- a/broker/tasks/shield.py
+++ b/broker/tasks/shield.py
@@ -109,6 +109,10 @@ def disassociate_health_check(operation_id: int, **kwargs):
 
     service_instance = operation.service_instance
 
+    if service_instance.shield_associated_health_check == None:
+        logger.info("No health check to disassociate from Shield")
+        return
+
     operation.step_description = "Disassociating health check with Shield"
     flag_modified(operation, "step_description")
     db.session.add(operation)

--- a/broker/tasks/waf.py
+++ b/broker/tasks/waf.py
@@ -90,6 +90,7 @@ def delete_web_acl(operation_id: str, **kwargs):
         not service_instance.dedicated_waf_web_acl_name
         or not service_instance.dedicated_waf_web_acl_id
     ):
+        logger.info("No WAF web ACL to delete")
         return
 
     _delete_web_acl_with_retries(operation_id, service_instance)

--- a/tests/integration/test_cloudwatch.py
+++ b/tests/integration/test_cloudwatch.py
@@ -613,3 +613,44 @@ def test_delete_health_check_alarms_unexpected_error(
 
     with pytest.raises(Exception):
         delete_health_check_alarms.call_local(operation_id)
+
+
+def test_delete_health_check_alarms_no_alarms(
+    clean_db,
+    service_instance_id,
+    service_instance,
+    operation_id,
+    cloudwatch_commercial,
+):
+    delete_health_check_alarms.call_local(operation_id)
+
+    cloudwatch_commercial.assert_no_pending_responses()
+
+    clean_db.session.expunge_all()
+
+    service_instance = clean_db.session.get(
+        CDNDedicatedWAFServiceInstance,
+        service_instance_id,
+    )
+    assert service_instance.cloudwatch_health_check_alarms == []
+
+
+def test_delete_health_check_alarms_unmigrated_instance(
+    clean_db,
+    service_instance_id,
+    unmigrated_cdn_dedicated_waf_service_instance_operation_id,
+    cloudwatch_commercial,
+):
+    delete_health_check_alarms.call_local(
+        unmigrated_cdn_dedicated_waf_service_instance_operation_id
+    )
+
+    cloudwatch_commercial.assert_no_pending_responses()
+
+    clean_db.session.expunge_all()
+
+    service_instance = clean_db.session.get(
+        CDNDedicatedWAFServiceInstance,
+        service_instance_id,
+    )
+    assert service_instance.cloudwatch_health_check_alarms == None

--- a/tests/integration/test_cron.py
+++ b/tests/integration/test_cron.py
@@ -1,7 +1,7 @@
 import pytest
+import datetime
 
-from broker.models import ServiceInstanceTypes
-from broker.tasks.cron import reschedule_operation
+from broker.tasks.cron import reschedule_operation, scan_for_stalled_pipelines
 
 from tests.lib.factories import (
     ALBServiceInstanceFactory,
@@ -27,6 +27,28 @@ def service_instance(clean_db, operation_id, service_instance_id, instance_facto
     return service_instance
 
 
+@pytest.fixture
+def stalled_service_instance(
+    clean_db, operation_id, service_instance_id, instance_factory
+):
+    service_instance = instance_factory.create(
+        id=service_instance_id,
+        domain_names=["example.com", "foo.com"],
+        domain_internal="fake1234.cloudfront.net",
+        route53_alias_hosted_zone="Z2FDTNDATAQYW2",
+    )
+    clean_db.session.add(service_instance)
+    clean_db.session.commit()
+    clean_db.session.expunge_all()
+    fifteen_minutes_ago = datetime.datetime.now() - datetime.timedelta(minutes=15)
+    OperationFactory.create(
+        id=operation_id,
+        service_instance=service_instance,
+        updated_at=fifteen_minutes_ago,
+    )
+    return service_instance
+
+
 @pytest.mark.parametrize(
     "instance_factory",
     [
@@ -39,3 +61,18 @@ def service_instance(clean_db, operation_id, service_instance_id, instance_facto
 def test_reschedule_operation_for_all_instance_types(service_instance, operation_id):
     result = reschedule_operation(operation_id)
     assert result is not None
+
+
+@pytest.mark.parametrize(
+    "instance_factory",
+    [
+        ALBServiceInstanceFactory,
+        CDNServiceInstanceFactory,
+        CDNDedicatedWAFServiceInstanceFactory,
+        DedicatedALBServiceInstanceFactory,
+    ],
+)
+def test_scan_for_stalled_pipelines(stalled_service_instance, operation_id):
+    # assert no error is thrown
+    operation_ids = scan_for_stalled_pipelines()
+    assert operation_ids == [int(operation_id)]

--- a/tests/integration/test_route53.py
+++ b/tests/integration/test_route53.py
@@ -310,3 +310,22 @@ def test_route53_deletes_health_checks(
     assert service_instance.route53_health_checks == []
     operation = clean_db.session.get(Operation, operation_id)
     assert operation.step_description == "Deleting health checks"
+
+
+def test_route53_deletes_health_checks_unmigrated_cdn_dedicated_waf_instance(
+    clean_db,
+    service_instance_id,
+    unmigrated_cdn_dedicated_waf_service_instance_operation_id,
+    route53,
+):
+    delete_health_checks.call_local(
+        unmigrated_cdn_dedicated_waf_service_instance_operation_id,
+    )
+
+    route53.assert_no_pending_responses()
+
+    clean_db.session.expunge_all()
+    service_instance = clean_db.session.get(
+        CDNDedicatedWAFServiceInstance, service_instance_id
+    )
+    assert service_instance.route53_health_checks == None

--- a/tests/integration/test_shield.py
+++ b/tests/integration/test_shield.py
@@ -250,3 +250,27 @@ def test_shield_disassociate_health_check(
     assert service_instance.shield_associated_health_check == None
     operation = clean_db.session.get(Operation, operation_id)
     assert operation.step_description == "Disassociating health check with Shield"
+
+
+def test_shield_disassociate_health_check_unmigrated_cdn_dedicated_waf_instance(
+    clean_db,
+    service_instance_id,
+    unmigrated_cdn_dedicated_waf_service_instance_operation_id,
+    shield,
+):
+    operation = clean_db.session.get(
+        Operation, unmigrated_cdn_dedicated_waf_service_instance_operation_id
+    )
+    service_instance = operation.service_instance
+
+    disassociate_health_check.call_local(
+        unmigrated_cdn_dedicated_waf_service_instance_operation_id
+    )
+
+    shield.assert_no_pending_responses()
+
+    clean_db.session.expunge_all()
+    service_instance = clean_db.session.get(
+        CDNDedicatedWAFServiceInstance, service_instance_id
+    )
+    assert service_instance.shield_associated_health_check == None

--- a/tests/integration/test_waf.py
+++ b/tests/integration/test_waf.py
@@ -183,3 +183,13 @@ def test_waf_delete_web_acl_succeeds_on_retry(
 
     waf._delete_web_acl_with_retries(operation_id, service_instance)
     wafv2.assert_no_pending_responses()
+
+
+def test_waf_delete_web_acl_unmigrated_cdn_dedicated_waf_instance(
+    unmigrated_cdn_dedicated_waf_service_instance_operation_id,
+    wafv2,
+):
+    waf.delete_web_acl.call_local(
+        unmigrated_cdn_dedicated_waf_service_instance_operation_id
+    )
+    wafv2.assert_no_pending_responses()

--- a/tests/lib/cdn/instances.py
+++ b/tests/lib/cdn/instances.py
@@ -59,7 +59,7 @@ def unmigrated_cdn_dedicated_waf_service_instance_operation_id(
         shield_associated_health_check=None,
         cloudwatch_health_check_alarms=None,
         cloudfront_distribution_arn=cloudfront_distribution_arn,
-        instance_type=ServiceInstanceTypes.CDN.value,
+        instance_type=ServiceInstanceTypes.CDN_DEDICATED_WAF.value,
     )
     clean_db.session.execute(create_cdn_instance_statement)
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Make retry logic for `wait_for_distribution_disabled` consistent with other code
- update `disassociate_health_check` to handle instance with missing columns
- update `delete_web_acl` to handle instances with missing columns
- update `delete_health_checks` to handle missing columns

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing broker bugs
