### PR TITLE
fix restart_stalled_pipelines and add test

### DIFF
--- a/broker/tasks/cron.py
+++ b/broker/tasks/cron.py
@@ -101,7 +101,7 @@ def scan_for_expiring_certs():
 @huey.huey.periodic_task(crontab(month="*", hour="*", day="*", minute="*/5"))
 def restart_stalled_pipelines():
     with huey.huey.flask_app.app_context():
-        for operation_id in scan_for_stalled_pipelines:
+        for operation_id in scan_for_stalled_pipelines():
             reschedule_operation(operation_id)
 
 

--- a/tests/integration/test_cron.py
+++ b/tests/integration/test_cron.py
@@ -1,7 +1,11 @@
 import pytest
 import datetime
 
-from broker.tasks.cron import reschedule_operation, scan_for_stalled_pipelines
+from broker.tasks.cron import (
+    reschedule_operation,
+    scan_for_stalled_pipelines,
+    restart_stalled_pipelines,
+)
 
 from tests.lib.factories import (
     ALBServiceInstanceFactory,
@@ -76,3 +80,17 @@ def test_scan_for_stalled_pipelines(stalled_service_instance, operation_id):
     # assert no error is thrown
     operation_ids = scan_for_stalled_pipelines()
     assert operation_ids == [int(operation_id)]
+
+
+@pytest.mark.parametrize(
+    "instance_factory",
+    [
+        ALBServiceInstanceFactory,
+        CDNServiceInstanceFactory,
+        CDNDedicatedWAFServiceInstanceFactory,
+        DedicatedALBServiceInstanceFactory,
+    ],
+)
+def test_restart_stalled_pipelines(stalled_service_instance):
+    # assert no error is thrown
+    restart_stalled_pipelines.call_local()


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix restart_stalled_pipelines to actualy call scan_for_stalled_pipelines
- add test to cover behavior

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing a bug
