### PR TITLE
Update delete tasks to handle empty values

### DIFF
--- a/broker/tasks/cloudwatch.py
+++ b/broker/tasks/cloudwatch.py
@@ -118,15 +118,6 @@ def delete_health_check_alarms(operation_id: int, **kwargs):
     db.session.add(operation)
     db.session.commit()
 
-    if (
-        service_instance.route53_health_checks == None
-        or len(service_instance.route53_health_checks) == 0
-    ):
-        logger.info(
-            f"No Route53 health checks to update alarms on instance {service_instance.id}"
-        )
-        return
-
     if service_instance.cloudwatch_health_check_alarms == None:
         existing_health_check_alarms = []
     else:

--- a/broker/tasks/shield.py
+++ b/broker/tasks/shield.py
@@ -110,7 +110,7 @@ def disassociate_health_check(operation_id: int, **kwargs):
     service_instance = operation.service_instance
 
     shield_associated_health_check = service_instance.shield_associated_health_check
-    if shield_associated_health_check == None or shield_associated_health_check == {}:
+    if shield_associated_health_check is None or shield_associated_health_check == {}:
         logger.info("No health check to disassociate from Shield")
         return
 

--- a/broker/tasks/shield.py
+++ b/broker/tasks/shield.py
@@ -110,7 +110,7 @@ def disassociate_health_check(operation_id: int, **kwargs):
     service_instance = operation.service_instance
 
     shield_associated_health_check = service_instance.shield_associated_health_check
-    if shield_associated_health_check == None:
+    if shield_associated_health_check == None or shield_associated_health_check == {}:
         logger.info("No health check to disassociate from Shield")
         return
 

--- a/broker/tasks/waf.py
+++ b/broker/tasks/waf.py
@@ -89,6 +89,7 @@ def delete_web_acl(operation_id: str, **kwargs):
     if (
         not service_instance.dedicated_waf_web_acl_name
         or not service_instance.dedicated_waf_web_acl_id
+        or not service_instance.dedicated_waf_web_acl_arn
     ):
         logger.info("No WAF web ACL to delete")
         return

--- a/tests/integration/test_cloudwatch.py
+++ b/tests/integration/test_cloudwatch.py
@@ -622,6 +622,17 @@ def test_delete_health_check_alarms_no_alarms(
     operation_id,
     cloudwatch_commercial,
 ):
+    service_instance.cloudwatch_health_check_alarms = []
+    clean_db.session.add(service_instance)
+    clean_db.session.commit()
+    clean_db.session.expunge_all()
+
+    service_instance = clean_db.session.get(
+        CDNDedicatedWAFServiceInstance,
+        service_instance_id,
+    )
+    assert service_instance.cloudwatch_health_check_alarms == []
+
     delete_health_check_alarms.call_local(operation_id)
 
     cloudwatch_commercial.assert_no_pending_responses()
@@ -641,6 +652,12 @@ def test_delete_health_check_alarms_unmigrated_instance(
     unmigrated_cdn_dedicated_waf_service_instance_operation_id,
     cloudwatch_commercial,
 ):
+    service_instance = clean_db.session.get(
+        CDNDedicatedWAFServiceInstance,
+        service_instance_id,
+    )
+    assert service_instance.cloudwatch_health_check_alarms == None
+
     delete_health_check_alarms.call_local(
         unmigrated_cdn_dedicated_waf_service_instance_operation_id
     )

--- a/tests/integration/test_cloudwatch.py
+++ b/tests/integration/test_cloudwatch.py
@@ -656,7 +656,7 @@ def test_delete_health_check_alarms_unmigrated_instance(
         CDNDedicatedWAFServiceInstance,
         service_instance_id,
     )
-    assert service_instance.cloudwatch_health_check_alarms == None
+    assert service_instance.cloudwatch_health_check_alarms is None
 
     delete_health_check_alarms.call_local(
         unmigrated_cdn_dedicated_waf_service_instance_operation_id

--- a/tests/integration/test_route53.py
+++ b/tests/integration/test_route53.py
@@ -312,6 +312,29 @@ def test_route53_deletes_health_checks(
     assert operation.step_description == "Deleting health checks"
 
 
+def test_route53_deletes_health_checks_empty(
+    clean_db,
+    service_instance_id,
+    service_instance,
+    operation_id,
+    route53,
+):
+    service_instance.route53_health_checks = []
+    clean_db.session.add(service_instance)
+    clean_db.session.commit()
+    clean_db.session.expunge_all()
+
+    delete_health_checks.call_local(operation_id)
+
+    route53.assert_no_pending_responses()
+
+    clean_db.session.expunge_all()
+    service_instance = clean_db.session.get(
+        CDNDedicatedWAFServiceInstance, service_instance_id
+    )
+    assert service_instance.route53_health_checks == []
+
+
 def test_route53_deletes_health_checks_unmigrated_cdn_dedicated_waf_instance(
     clean_db,
     service_instance_id,

--- a/tests/integration/test_shield.py
+++ b/tests/integration/test_shield.py
@@ -274,3 +274,23 @@ def test_shield_disassociate_health_check_unmigrated_cdn_dedicated_waf_instance(
         CDNDedicatedWAFServiceInstance, service_instance_id
     )
     assert service_instance.shield_associated_health_check == None
+
+
+def test_shield_disassociate_health_check_empty_check(
+    clean_db, service_instance_id, service_instance, operation_id, shield
+):
+    service_instance.shield_associated_health_check = {}
+
+    clean_db.session.add(service_instance)
+    clean_db.session.commit()
+    clean_db.session.expunge_all()
+
+    disassociate_health_check.call_local(operation_id)
+
+    shield.assert_no_pending_responses()
+
+    clean_db.session.expunge_all()
+    service_instance = clean_db.session.get(
+        CDNDedicatedWAFServiceInstance, service_instance_id
+    )
+    assert service_instance.shield_associated_health_check == {}

--- a/tests/integration/test_waf.py
+++ b/tests/integration/test_waf.py
@@ -148,10 +148,25 @@ def test_waf_delete_web_acl_gives_up_after_max_retries(
         waf._delete_web_acl_with_retries(operation_id, service_instance)
 
 
+def test_waf_delete_web_acl_handles_empty_values(
+    clean_db, service_instance, operation_id, wafv2
+):
+    service_instance.dedicated_waf_web_acl_id = None
+    service_instance.dedicated_waf_web_acl_name = None
+    service_instance.dedicated_waf_web_acl_arn = None
+
+    clean_db.session.add(service_instance)
+    clean_db.session.commit()
+    clean_db.session.expunge_all()
+
+    waf.delete_web_acl.call_local(operation_id)
+    wafv2.assert_no_pending_responses()
+
+
 def test_waf_delete_web_acl_succeeds_on_retry(
     clean_db, service_instance_id, service_instance, operation_id, wafv2
 ):
-    service_instance.dedicated_waf_web_acl_id = "1234-dedicated-waf-id"
+    service_instance.dedicated_waf_web_acl_id = None
     service_instance.dedicated_waf_web_acl_name = "1234-dedicated-waf"
     service_instance.dedicated_waf_web_acl_arn = "1234-dedicated-waf-arn"
 

--- a/tests/integration/test_waf.py
+++ b/tests/integration/test_waf.py
@@ -166,7 +166,7 @@ def test_waf_delete_web_acl_handles_empty_values(
 def test_waf_delete_web_acl_succeeds_on_retry(
     clean_db, service_instance_id, service_instance, operation_id, wafv2
 ):
-    service_instance.dedicated_waf_web_acl_id = None
+    service_instance.dedicated_waf_web_acl_id = "1234-dedicated-waf-id"
     service_instance.dedicated_waf_web_acl_name = "1234-dedicated-waf"
     service_instance.dedicated_waf_web_acl_arn = "1234-dedicated-waf-arn"
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update various delete tasks to ensure they handle empty values for the relevant columns correctly
- Add/update tests as necessary to ensure that tasks handle empty values correctly

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing broker bugs
