### PR TITLE
Update delete certificate logic

### DIFF
--- a/tests/integration/alb/test_alb_deprovisioning.py
+++ b/tests/integration/alb/test_alb_deprovisioning.py
@@ -7,8 +7,10 @@ from tests.lib.client import check_last_operation_description
 from tests.lib.alb.deprovision import (
     subtest_deprovision_creates_deprovision_operation,
     subtest_deprovision_removes_ALIAS_records,
-    subtest_deprovision_removes_TXT_records,
     subtest_deprovision_removes_cert_from_alb,
+)
+from tests.lib.deprovision import (
+    subtest_deprovision_removes_TXT_records,
     subtest_deprovision_removes_certificate_from_iam,
     subtest_deprovision_marks_operation_as_succeeded,
 )
@@ -84,7 +86,7 @@ def test_deprovision_happy_path(
     instance_model = ALBServiceInstance
     service_instance = db.session.get(instance_model, "1234")
     operation_id = subtest_deprovision_creates_deprovision_operation(
-        client, service_instance, instance_model
+        instance_model, client, service_instance
     )
     check_last_operation_description(client, "1234", operation_id, "Queuing tasks")
     subtest_deprovision_removes_ALIAS_records(tasks, route53)
@@ -96,16 +98,16 @@ def test_deprovision_happy_path(
         client, "1234", operation_id, "Removing DNS TXT records"
     )
     subtest_deprovision_removes_cert_from_alb(
-        tasks, service_instance, alb, instance_model
+        instance_model, tasks, service_instance, alb
     )
     check_last_operation_description(
         client, "1234", operation_id, "Removing SSL certificate from load balancer"
     )
     subtest_deprovision_removes_certificate_from_iam(
-        tasks, service_instance, iam_govcloud, instance_model
+        instance_model, tasks, service_instance, iam_govcloud
     )
     check_last_operation_description(
         client, "1234", operation_id, "Removing SSL certificate from AWS"
     )
-    subtest_deprovision_marks_operation_as_succeeded(tasks, instance_model)
+    subtest_deprovision_marks_operation_as_succeeded(instance_model, tasks)
     check_last_operation_description(client, "1234", operation_id, "Complete!")

--- a/tests/integration/alb/test_alb_deprovisioning.py
+++ b/tests/integration/alb/test_alb_deprovisioning.py
@@ -1,10 +1,17 @@
 import pytest  # noqa F401
 
 from broker.extensions import db
-from broker.models import Operation, ALBServiceInstance
+from broker.models import ALBServiceInstance
 from tests.lib import factories
 from tests.lib.client import check_last_operation_description
-from tests.lib.alb.deprovision import subtest_deprovision_removes_certificate_from_iam
+from tests.lib.alb.deprovision import (
+    subtest_deprovision_creates_deprovision_operation,
+    subtest_deprovision_removes_ALIAS_records,
+    subtest_deprovision_removes_TXT_records,
+    subtest_deprovision_removes_cert_from_alb,
+    subtest_deprovision_removes_certificate_from_iam,
+    subtest_deprovision_marks_operation_as_succeeded,
+)
 
 
 @pytest.fixture
@@ -72,11 +79,12 @@ def service_instance():
 
 
 def test_deprovision_happy_path(
-    client, service_instance, dns, tasks, route53, iam_govcloud, simple_regex, alb
+    client, service_instance, tasks, route53, iam_govcloud, alb
 ):
-    service_instance = db.session.get(ALBServiceInstance, "1234")
+    instance_model = ALBServiceInstance
+    service_instance = db.session.get(instance_model, "1234")
     operation_id = subtest_deprovision_creates_deprovision_operation(
-        client, service_instance
+        client, service_instance, instance_model
     )
     check_last_operation_description(client, "1234", operation_id, "Queuing tasks")
     subtest_deprovision_removes_ALIAS_records(tasks, route53)
@@ -87,84 +95,17 @@ def test_deprovision_happy_path(
     check_last_operation_description(
         client, "1234", operation_id, "Removing DNS TXT records"
     )
-    subtest_deprovision_removes_cert_from_alb(tasks, service_instance, alb)
+    subtest_deprovision_removes_cert_from_alb(
+        tasks, service_instance, alb, instance_model
+    )
     check_last_operation_description(
         client, "1234", operation_id, "Removing SSL certificate from load balancer"
     )
     subtest_deprovision_removes_certificate_from_iam(
-        tasks, service_instance, iam_govcloud
+        tasks, service_instance, iam_govcloud, instance_model
     )
     check_last_operation_description(
         client, "1234", operation_id, "Removing SSL certificate from AWS"
     )
-    subtest_deprovision_marks_operation_as_succeeded(tasks)
+    subtest_deprovision_marks_operation_as_succeeded(tasks, instance_model)
     check_last_operation_description(client, "1234", operation_id, "Complete!")
-
-
-def subtest_deprovision_creates_deprovision_operation(client, service_instance):
-    service_instance = db.session.get(ALBServiceInstance, "1234")
-    client.deprovision_alb_instance(service_instance.id, accepts_incomplete="true")
-
-    assert client.response.status_code == 202, client.response.body
-    assert "operation" in client.response.json
-
-    operation_id = client.response.json["operation"]
-    operation = db.session.get(Operation, operation_id)
-
-    assert operation is not None
-    assert operation.state == Operation.States.IN_PROGRESS.value
-    assert operation.action == Operation.Actions.DEPROVISION.value
-    assert operation.service_instance_id == service_instance.id
-
-    return operation_id
-
-
-def subtest_deprovision_removes_ALIAS_records(tasks, route53):
-    route53.expect_remove_ALIAS(
-        "example.com.domains.cloud.test", "fake1234.cloud.test", "ALBHOSTEDZONEID"
-    )
-    route53.expect_remove_ALIAS(
-        "foo.com.domains.cloud.test", "fake1234.cloud.test", "ALBHOSTEDZONEID"
-    )
-
-    # one for marking provisioning tasks canceled, which is tested elsewhere
-    tasks.run_queued_tasks_and_enqueue_dependents()
-    tasks.run_queued_tasks_and_enqueue_dependents()
-
-    route53.assert_no_pending_responses()
-
-
-def subtest_deprovision_removes_TXT_records(tasks, route53):
-    route53.expect_remove_TXT(
-        "_acme-challenge.example.com.domains.cloud.test", "example txt"
-    )
-    route53.expect_remove_TXT("_acme-challenge.foo.com.domains.cloud.test", "foo txt")
-
-    tasks.run_queued_tasks_and_enqueue_dependents()
-
-    route53.assert_no_pending_responses()
-
-
-def subtest_deprovision_removes_cert_from_alb(tasks, service_instance, alb):
-    service_instance = db.session.get(ALBServiceInstance, "1234")
-    alb.expect_remove_certificate_from_listener(
-        service_instance.alb_listener_arn,
-        service_instance.current_certificate.iam_server_certificate_arn,
-    )
-    tasks.run_queued_tasks_and_enqueue_dependents()
-    alb.assert_no_pending_responses()
-
-
-def subtest_deprovision_marks_operation_as_succeeded(tasks):
-    db.session.expunge_all()
-    service_instance = db.session.get(ALBServiceInstance, "1234")
-    assert not service_instance.deactivated_at
-
-    tasks.run_queued_tasks_and_enqueue_dependents()
-
-    db.session.expunge_all()
-    service_instance = db.session.get(ALBServiceInstance, "1234")
-    assert service_instance.deactivated_at
-
-    operation = service_instance.operations.first()
-    assert operation.state == "succeeded"

--- a/tests/integration/alb/test_alb_deprovisioning.py
+++ b/tests/integration/alb/test_alb_deprovisioning.py
@@ -4,6 +4,7 @@ from broker.extensions import db
 from broker.models import Operation, ALBServiceInstance
 from tests.lib import factories
 from tests.lib.client import check_last_operation_description
+from tests.lib.alb.deprovision import subtest_deprovision_removes_certificate_from_iam
 
 
 @pytest.fixture
@@ -152,31 +153,6 @@ def subtest_deprovision_removes_cert_from_alb(tasks, service_instance, alb):
     )
     tasks.run_queued_tasks_and_enqueue_dependents()
     alb.assert_no_pending_responses()
-
-
-def subtest_deprovision_removes_certificate_from_iam(
-    tasks, service_instance, iam_govcloud
-):
-    service_instance = db.session.get(ALBServiceInstance, "1234")
-    iam_govcloud.expects_delete_server_certificate(
-        service_instance.new_certificate.iam_server_certificate_name
-    )
-    iam_govcloud.expects_delete_server_certificate(
-        service_instance.current_certificate.iam_server_certificate_name
-    )
-    tasks.run_queued_tasks_and_enqueue_dependents()
-    iam_govcloud.assert_no_pending_responses()
-
-
-def subtest_deprovision_removes_certificate_from_iam_when_missing(
-    tasks, service_instance, iam_govcloud
-):
-    service_instance = db.session.get(ALBServiceInstance, "1234")
-    iam_govcloud.expects_delete_server_certificate_returning_no_such_entity(
-        name=service_instance.iam_server_certificate_name
-    )
-    tasks.run_queued_tasks_and_enqueue_dependents()
-    iam_govcloud.assert_no_pending_responses()
 
 
 def subtest_deprovision_marks_operation_as_succeeded(tasks):

--- a/tests/integration/cdn/test_cdn_deprovisioning.py
+++ b/tests/integration/cdn/test_cdn_deprovisioning.py
@@ -9,16 +9,18 @@ from tests.lib.cdn.deprovision import (
     subtest_deprovision_removes_TXT_records_when_missing,
     subtest_deprovision_removes_ALIAS_records_when_missing,
     subtest_deprovision_removes_ALIAS_records,
-    subtest_deprovision_removes_TXT_records,
     subtest_deprovision_disables_cloudfront_distribution,
     subtest_deprovision_waits_for_cloudfront_distribution_disabled,
     subtest_deprovision_removes_cloudfront_distribution,
     subtest_deprovision_disables_cloudfront_distribution_when_missing,
     subtest_deprovision_waits_for_cloudfront_distribution_disabled_when_missing,
     subtest_deprovision_removes_cloudfront_distribution_when_missing,
+)
+from tests.lib.deprovision import (
+    subtest_deprovision_removes_TXT_records,
     subtest_deprovision_removes_certificate_from_iam,
-    subtest_deprovision_removes_certificate_from_iam_when_missing,
     subtest_deprovision_marks_operation_as_succeeded,
+    subtest_deprovision_removes_certificate_from_iam_when_missing,
 )
 
 

--- a/tests/integration/cdn_dedicated_waf/test_cdn_dedicated_waf_deprovisioning.py
+++ b/tests/integration/cdn_dedicated_waf/test_cdn_dedicated_waf_deprovisioning.py
@@ -12,16 +12,18 @@ from tests.lib.cdn.deprovision import (
     subtest_deprovision_removes_TXT_records_when_missing,
     subtest_deprovision_removes_ALIAS_records_when_missing,
     subtest_deprovision_removes_ALIAS_records,
-    subtest_deprovision_removes_TXT_records,
     subtest_deprovision_disables_cloudfront_distribution,
     subtest_deprovision_waits_for_cloudfront_distribution_disabled,
     subtest_deprovision_removes_cloudfront_distribution,
     subtest_deprovision_disables_cloudfront_distribution_when_missing,
     subtest_deprovision_waits_for_cloudfront_distribution_disabled_when_missing,
     subtest_deprovision_removes_cloudfront_distribution_when_missing,
+)
+from tests.lib.deprovision import (
+    subtest_deprovision_removes_TXT_records,
     subtest_deprovision_removes_certificate_from_iam,
-    subtest_deprovision_removes_certificate_from_iam_when_missing,
     subtest_deprovision_marks_operation_as_succeeded,
+    subtest_deprovision_removes_certificate_from_iam_when_missing,
 )
 
 

--- a/tests/integration/dedicated_alb/test_dedicated_alb_deprovisioning.py
+++ b/tests/integration/dedicated_alb/test_dedicated_alb_deprovisioning.py
@@ -7,8 +7,10 @@ from tests.lib.client import check_last_operation_description
 from tests.lib.alb.deprovision import (
     subtest_deprovision_creates_deprovision_operation,
     subtest_deprovision_removes_ALIAS_records,
-    subtest_deprovision_removes_TXT_records,
     subtest_deprovision_removes_cert_from_alb,
+)
+from tests.lib.deprovision import (
+    subtest_deprovision_removes_TXT_records,
     subtest_deprovision_removes_certificate_from_iam,
     subtest_deprovision_marks_operation_as_succeeded,
 )
@@ -85,7 +87,7 @@ def test_deprovision_happy_path(
     instance_model = DedicatedALBServiceInstance
     service_instance = db.session.get(instance_model, "1234")
     operation_id = subtest_deprovision_creates_deprovision_operation(
-        client, service_instance, instance_model
+        instance_model, client, service_instance
     )
     check_last_operation_description(client, "1234", operation_id, "Queuing tasks")
     subtest_deprovision_removes_ALIAS_records(tasks, route53)
@@ -97,16 +99,22 @@ def test_deprovision_happy_path(
         client, "1234", operation_id, "Removing DNS TXT records"
     )
     subtest_deprovision_removes_cert_from_alb(
-        tasks, service_instance, alb, instance_model
+        instance_model,
+        tasks,
+        service_instance,
+        alb,
     )
     check_last_operation_description(
         client, "1234", operation_id, "Removing SSL certificate from load balancer"
     )
     subtest_deprovision_removes_certificate_from_iam(
-        tasks, service_instance, iam_govcloud, instance_model
+        instance_model,
+        tasks,
+        service_instance,
+        iam_govcloud,
     )
     check_last_operation_description(
         client, "1234", operation_id, "Removing SSL certificate from AWS"
     )
-    subtest_deprovision_marks_operation_as_succeeded(tasks, instance_model)
+    subtest_deprovision_marks_operation_as_succeeded(instance_model, tasks)
     check_last_operation_description(client, "1234", operation_id, "Complete!")

--- a/tests/integration/dedicated_alb/test_dedicated_alb_deprovisioning.py
+++ b/tests/integration/dedicated_alb/test_dedicated_alb_deprovisioning.py
@@ -4,6 +4,9 @@ from broker.extensions import db
 from broker.models import Operation, DedicatedALBServiceInstance
 from tests.lib import factories
 from tests.lib.client import check_last_operation_description
+from tests.lib.alb.deprovision import (
+    subtest_deprovision_removes_certificate_from_iam,
+)
 
 
 @pytest.fixture
@@ -155,31 +158,6 @@ def subtest_deprovision_removes_cert_from_alb(tasks, service_instance, alb):
     )
     tasks.run_queued_tasks_and_enqueue_dependents()
     alb.assert_no_pending_responses()
-
-
-def subtest_deprovision_removes_certificate_from_iam(
-    tasks, service_instance, iam_govcloud
-):
-    service_instance = db.session.get(DedicatedALBServiceInstance, "1234")
-    iam_govcloud.expects_delete_server_certificate(
-        service_instance.new_certificate.iam_server_certificate_name
-    )
-    iam_govcloud.expects_delete_server_certificate(
-        service_instance.current_certificate.iam_server_certificate_name
-    )
-    tasks.run_queued_tasks_and_enqueue_dependents()
-    iam_govcloud.assert_no_pending_responses()
-
-
-def subtest_deprovision_removes_certificate_from_iam_when_missing(
-    tasks, service_instance, iam_govcloud
-):
-    service_instance = db.session.get(DedicatedALBServiceInstance, "1234")
-    iam_govcloud.expects_delete_server_certificate_returning_no_such_entity(
-        name=service_instance.iam_server_certificate_name
-    )
-    tasks.run_queued_tasks_and_enqueue_dependents()
-    iam_govcloud.assert_no_pending_responses()
 
 
 def subtest_deprovision_marks_operation_as_succeeded(tasks):

--- a/tests/integration/test_iam_idempotent.py
+++ b/tests/integration/test_iam_idempotent.py
@@ -48,7 +48,6 @@ def service_instance(
     clean_db.session.add(current_cert)
     clean_db.session.add(new_cert)
     clean_db.session.commit()
-    clean_db.session.expunge_all()
     factories.OperationFactory.create(
         id=operation_id, service_instance=service_instance
     )
@@ -91,7 +90,6 @@ def alb_service_instance(
     clean_db.session.add(current_cert)
     clean_db.session.add(new_cert)
     clean_db.session.commit()
-    clean_db.session.expunge_all()
     factories.OperationFactory.create(
         id=operation_id, service_instance=service_instance
     )

--- a/tests/integration/test_iam_idempotent.py
+++ b/tests/integration/test_iam_idempotent.py
@@ -2,12 +2,20 @@ from datetime import date
 
 import pytest
 
+from broker.lib.cdn import is_cdn_instance
 from broker.tasks.iam import (
     upload_server_certificate,
     delete_server_certificate,
     delete_previous_server_certificate,
 )
-from broker.models import CDNServiceInstance, Operation, Certificate
+from broker.models import (
+    ALBServiceInstance,
+    CDNServiceInstance,
+    DedicatedALBServiceInstance,
+    CDNDedicatedWAFServiceInstance,
+    Operation,
+    Certificate,
+)
 
 from tests.lib import factories
 from tests.lib.identifiers import get_server_certificate_name
@@ -15,18 +23,18 @@ from tests.lib.identifiers import get_server_certificate_name
 
 @pytest.fixture
 def service_instance(
-    clean_db, service_instance_id, operation_id, current_cert_id, new_cert_id
+    clean_db,
+    instance_factory,
+    service_instance_id,
+    operation_id,
+    current_cert_id,
+    new_cert_id,
 ):
-    service_instance = factories.CDNServiceInstanceFactory.create(
+    service_instance = instance_factory.create(
         id=service_instance_id,
         domain_names=["example.com", "foo.com"],
         domain_internal="fake1234.cloudfront.net",
         route53_alias_hosted_zone="Z2FDTNDATAQYW2",
-        cloudfront_distribution_id="FakeDistributionId",
-        cloudfront_origin_hostname="origin_hostname",
-        cloudfront_origin_path="origin_path",
-        origin_protocol_policy="https-only",
-        forwarded_headers=["HOST"],
     )
     new_cert = factories.CertificateFactory.create(
         service_instance=service_instance,
@@ -35,54 +43,18 @@ def service_instance(
         leaf_pem="SOMECERTPEM",
         fullchain_pem="FULLCHAINOFSOMECERTPEM",
         id=new_cert_id,
-    )
-    current_cert = factories.CertificateFactory.create(
-        service_instance=service_instance,
-        private_key_pem="SOMEPRIVATEKEY",
-        iam_server_certificate_id="certificate_id",
-        id=current_cert_id,
-    )
-    service_instance.current_certificate = current_cert
-    service_instance.new_certificate = new_cert
-    clean_db.session.add(service_instance)
-    clean_db.session.add(current_cert)
-    clean_db.session.add(new_cert)
-    clean_db.session.commit()
-    factories.OperationFactory.create(
-        id=operation_id, service_instance=service_instance
-    )
-    return service_instance
-
-
-@pytest.fixture
-def alb_service_instance(
-    clean_db, service_instance_id, operation_id, current_cert_id, new_cert_id
-):
-    service_instance = factories.ALBServiceInstanceFactory.create(
-        id=service_instance_id,
-        domain_names=["example.com", "foo.com"],
-        domain_internal="fake1234.cloudfront.net",
-        route53_alias_hosted_zone="Z2FDTNDATAQYW2",
-    )
-    new_cert = factories.CertificateFactory.create(
-        service_instance=service_instance,
-        private_key_pem="SOMEPRIVATEKEY",
-        iam_server_certificate_id="certificate_id",
-        leaf_pem="SOMECERTPEM",
-        fullchain_pem="FULLCHAINOFSOMECERTPEM",
         iam_server_certificate_name=get_server_certificate_name(
             service_instance_id, new_cert_id
         ),
-        id=new_cert_id,
     )
     current_cert = factories.CertificateFactory.create(
         service_instance=service_instance,
         private_key_pem="SOMEPRIVATEKEY",
         iam_server_certificate_id="certificate_id",
+        id=current_cert_id,
         iam_server_certificate_name=get_server_certificate_name(
             service_instance_id, current_cert_id
         ),
-        id=current_cert_id,
     )
     service_instance.current_certificate = current_cert
     service_instance.new_certificate = new_cert
@@ -97,35 +69,65 @@ def alb_service_instance(
 
 
 @pytest.fixture
-def alb_service_instance_without_new_cert(clean_db, alb_service_instance):
-    alb_service_instance.new_certificate = None
-    clean_db.session.add(alb_service_instance)
+def service_instance_without_new_cert(clean_db, service_instance):
+    service_instance.new_certificate = None
+    clean_db.session.add(service_instance)
     clean_db.session.commit()
-    return alb_service_instance
+    return service_instance
 
 
+@pytest.fixture
+def iam(iam_commercial, iam_govcloud, service_instance):
+    if is_cdn_instance(service_instance):
+        iam = iam_commercial
+    else:
+        iam = iam_govcloud
+    return iam
+
+
+@pytest.fixture
+def iam_certificate_path(service_instance):
+    if is_cdn_instance(service_instance):
+        path = "/cloudfront/external-domains-test/"
+    else:
+        path = "/alb/external-domains-test/"
+    return path
+
+
+@pytest.mark.parametrize(
+    "instance_factory, instance_model",
+    [
+        [factories.ALBServiceInstanceFactory, ALBServiceInstance],
+        [factories.CDNServiceInstanceFactory, CDNServiceInstance],
+        [factories.DedicatedALBServiceInstanceFactory, DedicatedALBServiceInstance],
+        [
+            factories.CDNDedicatedWAFServiceInstanceFactory,
+            CDNDedicatedWAFServiceInstance,
+        ],
+    ],
+)
 def test_reupload_certificate_ok(
     clean_db,
-    iam_commercial,
+    instance_model,
+    iam,
+    iam_certificate_path,
     service_instance,
     simple_regex,
     operation_id,
     service_instance_id,
 ):
-    clean_db.session.expunge_all()
-    service_instance = clean_db.session.get(CDNServiceInstance, service_instance_id)
     certificate = service_instance.new_certificate
     today = date.today().isoformat()
     assert today == simple_regex(r"^\d\d\d\d-\d\d-\d\d$")
 
-    iam_commercial.expect_upload_server_certificate(
+    iam.expect_upload_server_certificate(
         name=get_server_certificate_name(service_instance_id, certificate.id),
         cert=certificate.leaf_pem,
         private_key=certificate.private_key_pem,
         chain=certificate.fullchain_pem,
-        path="/cloudfront/external-domains-test/",
+        path=iam_certificate_path,
     )
-    iam_commercial.expect_tag_server_certificate(
+    iam.expect_tag_server_certificate(
         get_server_certificate_name(service_instance_id, certificate.id),
         [],
     )
@@ -133,27 +135,35 @@ def test_reupload_certificate_ok(
     upload_server_certificate.call_local(operation_id)
 
     clean_db.session.expunge_all()
-    service_instance = clean_db.session.get(CDNServiceInstance, service_instance_id)
+    service_instance = clean_db.session.get(instance_model, service_instance_id)
     certificate = service_instance.new_certificate
     operation = clean_db.session.get(Operation, operation_id)
     updated_at = operation.updated_at.timestamp()
-    clean_db.session.expunge_all()
+
     # unstubbed, so an error should be raised if we do try
+    clean_db.session.expunge_all()
     upload_server_certificate.call_local(operation_id)
     operation = clean_db.session.get(Operation, operation_id)
     assert updated_at != operation.updated_at.timestamp()
 
 
+@pytest.mark.parametrize(
+    "instance_factory",
+    [
+        factories.ALBServiceInstanceFactory,
+        factories.CDNServiceInstanceFactory,
+        factories.DedicatedALBServiceInstanceFactory,
+        factories.CDNDedicatedWAFServiceInstanceFactory,
+    ],
+)
 def test_upload_certificate_already_exists(
-    clean_db,
-    iam_commercial,
+    iam,
+    iam_certificate_path,
     service_instance_id,
     simple_regex,
     operation_id,
     service_instance,
 ):
-    clean_db.session.expunge_all()
-    service_instance = clean_db.session.get(CDNServiceInstance, service_instance_id)
     certificate = service_instance.new_certificate
     today = date.today().isoformat()
     assert today == simple_regex(r"^\d\d\d\d-\d\d-\d\d$")
@@ -161,134 +171,164 @@ def test_upload_certificate_already_exists(
     server_certificate_name = get_server_certificate_name(
         service_instance_id, certificate.id
     )
-    iam_commercial.expect_upload_server_certificate_raising_duplicate(
+    iam.expect_upload_server_certificate_raising_duplicate(
         name=server_certificate_name,
         cert=certificate.leaf_pem,
         private_key=certificate.private_key_pem,
         chain=certificate.fullchain_pem,
-        path="/cloudfront/external-domains-test/",
+        path=iam_certificate_path,
     )
-    iam_commercial.expect_get_server_certificate(
+    iam.expect_get_server_certificate(
         name=server_certificate_name,
     )
-    iam_commercial.expect_tag_server_certificate(
+    iam.expect_tag_server_certificate(
         server_certificate_name,
         [],
     )
 
     upload_server_certificate.call_local(operation_id)
 
-    iam_commercial.assert_no_pending_responses()
+    iam.assert_no_pending_responses()
 
 
+@pytest.mark.parametrize(
+    "instance_factory",
+    [
+        factories.ALBServiceInstanceFactory,
+        factories.CDNServiceInstanceFactory,
+        factories.DedicatedALBServiceInstanceFactory,
+        factories.CDNDedicatedWAFServiceInstanceFactory,
+    ],
+)
 def test_delete_server_certificate(
     clean_db,
-    iam_govcloud,
-    alb_service_instance,
+    iam,
+    service_instance,
     operation_id,
     current_cert_id,
     new_cert_id,
 ):
-    iam_govcloud.expect_get_server_certificate(
-        get_server_certificate_name(alb_service_instance.id, new_cert_id),
+    iam.expect_get_server_certificate(
+        get_server_certificate_name(service_instance.id, new_cert_id),
     )
-    iam_govcloud.expects_delete_server_certificate(
-        get_server_certificate_name(alb_service_instance.id, new_cert_id),
+    iam.expects_delete_server_certificate(
+        get_server_certificate_name(service_instance.id, new_cert_id),
     )
-    iam_govcloud.expect_get_server_certificate(
-        get_server_certificate_name(alb_service_instance.id, current_cert_id),
+    iam.expect_get_server_certificate(
+        get_server_certificate_name(service_instance.id, current_cert_id),
     )
-    iam_govcloud.expects_delete_server_certificate(
-        get_server_certificate_name(alb_service_instance.id, current_cert_id),
+    iam.expects_delete_server_certificate(
+        get_server_certificate_name(service_instance.id, current_cert_id),
     )
 
     delete_server_certificate.call_local(operation_id)
 
-    iam_govcloud.assert_no_pending_responses()
+    iam.assert_no_pending_responses()
 
     clean_db.session.expunge_all()
 
 
+@pytest.mark.parametrize(
+    "instance_factory",
+    [
+        factories.ALBServiceInstanceFactory,
+        factories.CDNServiceInstanceFactory,
+        factories.DedicatedALBServiceInstanceFactory,
+        factories.CDNDedicatedWAFServiceInstanceFactory,
+    ],
+)
 def test_delete_server_certificate_current_cert_missing(
     clean_db,
-    iam_govcloud,
-    alb_service_instance,
-    service_instance_id,
+    iam,
+    service_instance,
     operation_id,
     current_cert_id,
     new_cert_id,
 ):
-    assert alb_service_instance.current_certificate is not None
-    assert alb_service_instance.new_certificate is not None
+    assert service_instance.current_certificate is not None
+    assert service_instance.new_certificate is not None
 
-    iam_govcloud.expect_get_server_certificate(
-        get_server_certificate_name(service_instance_id, new_cert_id),
+    iam.expect_get_server_certificate(
+        get_server_certificate_name(service_instance.id, new_cert_id),
     )
-    iam_govcloud.expects_delete_server_certificate(
-        get_server_certificate_name(service_instance_id, new_cert_id),
+    iam.expects_delete_server_certificate(
+        get_server_certificate_name(service_instance.id, new_cert_id),
     )
-    iam_govcloud.expect_get_server_certificate_returning_no_such_entity(
-        get_server_certificate_name(service_instance_id, current_cert_id),
+    iam.expect_get_server_certificate_returning_no_such_entity(
+        get_server_certificate_name(service_instance.id, current_cert_id),
     )
 
     delete_server_certificate.call_local(operation_id)
 
-    iam_govcloud.assert_no_pending_responses()
+    iam.assert_no_pending_responses()
 
     clean_db.session.expunge_all()
 
 
+@pytest.mark.parametrize(
+    "instance_factory",
+    [
+        factories.ALBServiceInstanceFactory,
+        factories.CDNServiceInstanceFactory,
+        factories.DedicatedALBServiceInstanceFactory,
+        factories.CDNDedicatedWAFServiceInstanceFactory,
+    ],
+)
 def test_delete_server_certificate_new_cert_missing(
     clean_db,
-    iam_govcloud,
-    alb_service_instance,
-    service_instance_id,
+    iam,
+    service_instance,
     operation_id,
     current_cert_id,
     new_cert_id,
 ):
-    assert alb_service_instance.current_certificate is not None
-    assert alb_service_instance.new_certificate is not None
+    assert service_instance.current_certificate is not None
+    assert service_instance.new_certificate is not None
 
-    iam_govcloud.expect_get_server_certificate_returning_no_such_entity(
-        get_server_certificate_name(service_instance_id, new_cert_id),
+    iam.expect_get_server_certificate_returning_no_such_entity(
+        get_server_certificate_name(service_instance.id, new_cert_id),
     )
-    iam_govcloud.expect_get_server_certificate(
-        get_server_certificate_name(service_instance_id, current_cert_id),
+    iam.expect_get_server_certificate(
+        get_server_certificate_name(service_instance.id, current_cert_id),
     )
-    iam_govcloud.expects_delete_server_certificate(
-        get_server_certificate_name(service_instance_id, current_cert_id),
+    iam.expects_delete_server_certificate(
+        get_server_certificate_name(service_instance.id, current_cert_id),
     )
 
     delete_server_certificate.call_local(operation_id)
 
-    iam_govcloud.assert_no_pending_responses()
+    iam.assert_no_pending_responses()
 
     clean_db.session.expunge_all()
 
 
+@pytest.mark.parametrize(
+    "instance_factory",
+    [
+        factories.ALBServiceInstanceFactory,
+        factories.CDNServiceInstanceFactory,
+        factories.DedicatedALBServiceInstanceFactory,
+        factories.CDNDedicatedWAFServiceInstanceFactory,
+    ],
+)
 def test_delete_previous_server_certificate_happy_path(
     clean_db,
-    iam_govcloud,
-    alb_service_instance_without_new_cert,
+    iam,
+    service_instance_without_new_cert,
     operation_id,
     new_cert_id,
 ):
     certificate = clean_db.session.get(Certificate, new_cert_id)
-    iam_govcloud.expect_get_server_certificate(
-        get_server_certificate_name(
-            alb_service_instance_without_new_cert.id, new_cert_id
-        ),
+    iam.expect_get_server_certificate(
+        get_server_certificate_name(service_instance_without_new_cert.id, new_cert_id),
     )
-    iam_govcloud.expects_delete_server_certificate(
-        get_server_certificate_name(
-            alb_service_instance_without_new_cert.id, new_cert_id
-        ),
+    iam.expects_delete_server_certificate(
+        get_server_certificate_name(service_instance_without_new_cert.id, new_cert_id),
     )
 
     delete_previous_server_certificate.call_local(operation_id)
 
-    iam_govcloud.assert_no_pending_responses()
+    iam.assert_no_pending_responses()
 
     clean_db.session.expunge_all()
 
@@ -296,41 +336,53 @@ def test_delete_previous_server_certificate_happy_path(
     assert not certificate
 
 
+@pytest.mark.parametrize(
+    "instance_factory",
+    [
+        factories.ALBServiceInstanceFactory,
+        factories.CDNServiceInstanceFactory,
+        factories.DedicatedALBServiceInstanceFactory,
+        factories.CDNDedicatedWAFServiceInstanceFactory,
+    ],
+)
 def test_delete_previous_server_certificate_unexpected_error(
-    iam_govcloud, alb_service_instance_without_new_cert, operation_id, new_cert_id
+    iam, service_instance_without_new_cert, operation_id, new_cert_id
 ):
-    iam_govcloud.expect_get_server_certificate(
-        get_server_certificate_name(
-            alb_service_instance_without_new_cert.id, new_cert_id
-        ),
+    iam.expect_get_server_certificate(
+        get_server_certificate_name(service_instance_without_new_cert.id, new_cert_id),
     )
-    iam_govcloud.expects_delete_server_certificate_unexpected_error(
-        get_server_certificate_name(
-            alb_service_instance_without_new_cert.id, new_cert_id
-        ),
+    iam.expects_delete_server_certificate_unexpected_error(
+        get_server_certificate_name(service_instance_without_new_cert.id, new_cert_id),
     )
 
     with pytest.raises(Exception):
         delete_previous_server_certificate.call_local(operation_id)
 
-    iam_govcloud.assert_no_pending_responses()
+    iam.assert_no_pending_responses()
 
 
+@pytest.mark.parametrize(
+    "instance_factory",
+    [
+        factories.ALBServiceInstanceFactory,
+        factories.CDNServiceInstanceFactory,
+        factories.DedicatedALBServiceInstanceFactory,
+        factories.CDNDedicatedWAFServiceInstanceFactory,
+    ],
+)
 def test_delete_previous_server_certificate_already_deleted(
     clean_db,
-    iam_govcloud,
-    alb_service_instance_without_new_cert,
+    iam,
+    service_instance_without_new_cert,
     operation_id,
     new_cert_id,
 ):
-    iam_govcloud.expects_get_server_certificate_returning_no_such_entity(
-        get_server_certificate_name(
-            alb_service_instance_without_new_cert.id, new_cert_id
-        ),
+    iam.expects_get_server_certificate_returning_no_such_entity(
+        get_server_certificate_name(service_instance_without_new_cert.id, new_cert_id),
     )
     delete_previous_server_certificate.call_local(operation_id)
 
-    iam_govcloud.assert_no_pending_responses()
+    iam.assert_no_pending_responses()
 
     clean_db.session.expunge_all()
 
@@ -338,24 +390,29 @@ def test_delete_previous_server_certificate_already_deleted(
     assert not certificate
 
 
+@pytest.mark.parametrize(
+    "instance_factory",
+    [
+        factories.ALBServiceInstanceFactory,
+        factories.CDNServiceInstanceFactory,
+        factories.DedicatedALBServiceInstanceFactory,
+        factories.CDNDedicatedWAFServiceInstanceFactory,
+    ],
+)
 def test_delete_previous_server_certificate_error_on_get_server_certificate(
-    iam_govcloud,
-    alb_service_instance_without_new_cert,
+    iam,
+    service_instance_without_new_cert,
     operation_id,
     new_cert_id,
 ):
-    iam_govcloud.expects_get_server_certificate_unexpected_error(
-        get_server_certificate_name(
-            alb_service_instance_without_new_cert.id, new_cert_id
-        ),
+    iam.expects_get_server_certificate_unexpected_error(
+        get_server_certificate_name(service_instance_without_new_cert.id, new_cert_id),
     )
-    iam_govcloud.expects_delete_server_certificate_access_denied(
-        get_server_certificate_name(
-            alb_service_instance_without_new_cert.id, new_cert_id
-        ),
+    iam.expects_delete_server_certificate_access_denied(
+        get_server_certificate_name(service_instance_without_new_cert.id, new_cert_id),
     )
 
     with pytest.raises(Exception):
         delete_previous_server_certificate.call_local(operation_id)
 
-    iam_govcloud.assert_no_pending_responses()
+    iam.assert_no_pending_responses()

--- a/tests/lib/alb/deprovision.py
+++ b/tests/lib/alb/deprovision.py
@@ -1,0 +1,33 @@
+from broker.extensions import db
+from broker.models import ALBServiceInstance
+
+
+def subtest_deprovision_removes_certificate_from_iam(
+    tasks, service_instance, iam_govcloud
+):
+    service_instance = db.session.get(ALBServiceInstance, "1234")
+    iam_govcloud.expect_get_server_certificate(
+        service_instance.new_certificate.iam_server_certificate_name
+    )
+    iam_govcloud.expects_delete_server_certificate(
+        service_instance.new_certificate.iam_server_certificate_name
+    )
+    iam_govcloud.expect_get_server_certificate(
+        service_instance.current_certificate.iam_server_certificate_name
+    )
+    iam_govcloud.expects_delete_server_certificate(
+        service_instance.current_certificate.iam_server_certificate_name
+    )
+    tasks.run_queued_tasks_and_enqueue_dependents()
+    iam_govcloud.assert_no_pending_responses()
+
+
+def subtest_deprovision_removes_certificate_from_iam_when_missing(
+    tasks, service_instance, iam_govcloud
+):
+    service_instance = db.session.get(ALBServiceInstance, "1234")
+    iam_govcloud.expect_get_server_certificate_returning_no_such_entity(
+        name=service_instance.iam_server_certificate_name
+    )
+    tasks.run_queued_tasks_and_enqueue_dependents()
+    iam_govcloud.assert_no_pending_responses()

--- a/tests/lib/alb/deprovision.py
+++ b/tests/lib/alb/deprovision.py
@@ -3,7 +3,7 @@ from broker.models import Operation
 
 
 def subtest_deprovision_creates_deprovision_operation(
-    client, service_instance, instance_model
+    instance_model, client, service_instance
 ):
     service_instance = db.session.get(instance_model, "1234")
     client.deprovision_alb_instance(service_instance.id, accepts_incomplete="true")
@@ -37,19 +37,8 @@ def subtest_deprovision_removes_ALIAS_records(tasks, route53):
     route53.assert_no_pending_responses()
 
 
-def subtest_deprovision_removes_TXT_records(tasks, route53):
-    route53.expect_remove_TXT(
-        "_acme-challenge.example.com.domains.cloud.test", "example txt"
-    )
-    route53.expect_remove_TXT("_acme-challenge.foo.com.domains.cloud.test", "foo txt")
-
-    tasks.run_queued_tasks_and_enqueue_dependents()
-
-    route53.assert_no_pending_responses()
-
-
 def subtest_deprovision_removes_cert_from_alb(
-    tasks, service_instance, alb, instance_model
+    instance_model, tasks, service_instance, alb
 ):
     service_instance = db.session.get(instance_model, "1234")
     alb.expect_remove_certificate_from_listener(
@@ -58,38 +47,3 @@ def subtest_deprovision_removes_cert_from_alb(
     )
     tasks.run_queued_tasks_and_enqueue_dependents()
     alb.assert_no_pending_responses()
-
-
-def subtest_deprovision_removes_certificate_from_iam(
-    tasks, service_instance, iam_govcloud, instance_model
-):
-    service_instance = db.session.get(instance_model, "1234")
-    iam_govcloud.expect_get_server_certificate(
-        service_instance.new_certificate.iam_server_certificate_name
-    )
-    iam_govcloud.expects_delete_server_certificate(
-        service_instance.new_certificate.iam_server_certificate_name
-    )
-    iam_govcloud.expect_get_server_certificate(
-        service_instance.current_certificate.iam_server_certificate_name
-    )
-    iam_govcloud.expects_delete_server_certificate(
-        service_instance.current_certificate.iam_server_certificate_name
-    )
-    tasks.run_queued_tasks_and_enqueue_dependents()
-    iam_govcloud.assert_no_pending_responses()
-
-
-def subtest_deprovision_marks_operation_as_succeeded(tasks, instance_model):
-    db.session.expunge_all()
-    service_instance = db.session.get(instance_model, "1234")
-    assert not service_instance.deactivated_at
-
-    tasks.run_queued_tasks_and_enqueue_dependents()
-
-    db.session.expunge_all()
-    service_instance = db.session.get(instance_model, "1234")
-    assert service_instance.deactivated_at
-
-    operation = service_instance.operations.first()
-    assert operation.state == "succeeded"

--- a/tests/lib/alb/deprovision.py
+++ b/tests/lib/alb/deprovision.py
@@ -1,11 +1,69 @@
 from broker.extensions import db
-from broker.models import ALBServiceInstance
+from broker.models import Operation
+
+
+def subtest_deprovision_creates_deprovision_operation(
+    client, service_instance, instance_model
+):
+    service_instance = db.session.get(instance_model, "1234")
+    client.deprovision_alb_instance(service_instance.id, accepts_incomplete="true")
+
+    assert client.response.status_code == 202, client.response.body
+    assert "operation" in client.response.json
+
+    operation_id = client.response.json["operation"]
+    operation = db.session.get(Operation, operation_id)
+
+    assert operation is not None
+    assert operation.state == Operation.States.IN_PROGRESS.value
+    assert operation.action == Operation.Actions.DEPROVISION.value
+    assert operation.service_instance_id == service_instance.id
+
+    return operation_id
+
+
+def subtest_deprovision_removes_ALIAS_records(tasks, route53):
+    route53.expect_remove_ALIAS(
+        "example.com.domains.cloud.test", "fake1234.cloud.test", "ALBHOSTEDZONEID"
+    )
+    route53.expect_remove_ALIAS(
+        "foo.com.domains.cloud.test", "fake1234.cloud.test", "ALBHOSTEDZONEID"
+    )
+
+    # one for marking provisioning tasks canceled, which is tested elsewhere
+    tasks.run_queued_tasks_and_enqueue_dependents()
+    tasks.run_queued_tasks_and_enqueue_dependents()
+
+    route53.assert_no_pending_responses()
+
+
+def subtest_deprovision_removes_TXT_records(tasks, route53):
+    route53.expect_remove_TXT(
+        "_acme-challenge.example.com.domains.cloud.test", "example txt"
+    )
+    route53.expect_remove_TXT("_acme-challenge.foo.com.domains.cloud.test", "foo txt")
+
+    tasks.run_queued_tasks_and_enqueue_dependents()
+
+    route53.assert_no_pending_responses()
+
+
+def subtest_deprovision_removes_cert_from_alb(
+    tasks, service_instance, alb, instance_model
+):
+    service_instance = db.session.get(instance_model, "1234")
+    alb.expect_remove_certificate_from_listener(
+        service_instance.alb_listener_arn,
+        service_instance.current_certificate.iam_server_certificate_arn,
+    )
+    tasks.run_queued_tasks_and_enqueue_dependents()
+    alb.assert_no_pending_responses()
 
 
 def subtest_deprovision_removes_certificate_from_iam(
-    tasks, service_instance, iam_govcloud
+    tasks, service_instance, iam_govcloud, instance_model
 ):
-    service_instance = db.session.get(ALBServiceInstance, "1234")
+    service_instance = db.session.get(instance_model, "1234")
     iam_govcloud.expect_get_server_certificate(
         service_instance.new_certificate.iam_server_certificate_name
     )
@@ -22,12 +80,16 @@ def subtest_deprovision_removes_certificate_from_iam(
     iam_govcloud.assert_no_pending_responses()
 
 
-def subtest_deprovision_removes_certificate_from_iam_when_missing(
-    tasks, service_instance, iam_govcloud
-):
-    service_instance = db.session.get(ALBServiceInstance, "1234")
-    iam_govcloud.expect_get_server_certificate_returning_no_such_entity(
-        name=service_instance.iam_server_certificate_name
-    )
+def subtest_deprovision_marks_operation_as_succeeded(tasks, instance_model):
+    db.session.expunge_all()
+    service_instance = db.session.get(instance_model, "1234")
+    assert not service_instance.deactivated_at
+
     tasks.run_queued_tasks_and_enqueue_dependents()
-    iam_govcloud.assert_no_pending_responses()
+
+    db.session.expunge_all()
+    service_instance = db.session.get(instance_model, "1234")
+    assert service_instance.deactivated_at
+
+    operation = service_instance.operations.first()
+    assert operation.state == "succeeded"

--- a/tests/lib/deprovision.py
+++ b/tests/lib/deprovision.py
@@ -1,0 +1,82 @@
+from broker.extensions import db
+from broker.models import Operation
+
+
+def subtest_deprovision_removes_certificate_from_iam(
+    instance_model, tasks, service_instance, iam_govcloud
+):
+    service_instance = db.session.get(instance_model, "1234")
+    iam_govcloud.expect_get_server_certificate(
+        service_instance.new_certificate.iam_server_certificate_name
+    )
+    iam_govcloud.expects_delete_server_certificate(
+        service_instance.new_certificate.iam_server_certificate_name
+    )
+    iam_govcloud.expect_get_server_certificate(
+        service_instance.current_certificate.iam_server_certificate_name
+    )
+    iam_govcloud.expects_delete_server_certificate(
+        service_instance.current_certificate.iam_server_certificate_name
+    )
+    tasks.run_queued_tasks_and_enqueue_dependents()
+    iam_govcloud.assert_no_pending_responses()
+
+
+def subtest_deprovision_removes_TXT_records(tasks, route53):
+    route53.expect_remove_TXT(
+        "_acme-challenge.example.com.domains.cloud.test", "example txt"
+    )
+    route53.expect_remove_TXT("_acme-challenge.foo.com.domains.cloud.test", "foo txt")
+
+    tasks.run_queued_tasks_and_enqueue_dependents()
+
+    route53.assert_no_pending_responses()
+
+
+def subtest_deprovision_removes_certificate_from_iam(
+    instance_model, tasks, service_instance, iam
+):
+    service_instance = db.session.get(instance_model, "1234")
+    iam.expect_get_server_certificate(
+        service_instance.new_certificate.iam_server_certificate_name
+    )
+    iam.expects_delete_server_certificate(
+        service_instance.new_certificate.iam_server_certificate_name
+    )
+    iam.expect_get_server_certificate(
+        service_instance.current_certificate.iam_server_certificate_name
+    )
+    iam.expects_delete_server_certificate(
+        service_instance.current_certificate.iam_server_certificate_name
+    )
+    tasks.run_queued_tasks_and_enqueue_dependents()
+    iam.assert_no_pending_responses()
+
+
+def subtest_deprovision_removes_certificate_from_iam_when_missing(
+    instance_model, tasks, service_instance, iam
+):
+    service_instance = db.session.get(instance_model, "1234")
+    iam.expect_get_server_certificate_returning_no_such_entity(
+        name=service_instance.new_certificate.iam_server_certificate_name
+    )
+    iam.expect_get_server_certificate_returning_no_such_entity(
+        name=service_instance.current_certificate.iam_server_certificate_name
+    )
+    tasks.run_queued_tasks_and_enqueue_dependents()
+    iam.assert_no_pending_responses()
+
+
+def subtest_deprovision_marks_operation_as_succeeded(instance_model, tasks):
+    db.session.expunge_all()
+    service_instance = db.session.get(instance_model, "1234")
+    assert not service_instance.deactivated_at
+
+    tasks.run_queued_tasks_and_enqueue_dependents()
+
+    db.session.expunge_all()
+    service_instance = db.session.get(instance_model, "1234")
+    assert service_instance.deactivated_at
+
+    operation = service_instance.operations.first()
+    assert operation.state == "succeeded"

--- a/tests/lib/fake_iam.py
+++ b/tests/lib/fake_iam.py
@@ -54,6 +54,15 @@ class FakeIAM(FakeAWS):
         )
         self.stubber.add_response(method, response, request)
 
+    def expect_get_server_certificate_returning_no_such_entity(self, name: str):
+        self.stubber.add_client_error(
+            "get_server_certificate",
+            service_error_code="NoSuchEntity",
+            service_message="'Ain't there.",
+            http_status_code=404,
+            expected_params={"ServerCertificateName": name},
+        )
+
     def server_certificate_metadata_response(
         self, name: str, cert: str, chain: str, path: str
     ):


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add logic to check for certificate before attempting deletion. Skip deletion if certificate does not exist
- Refactor tests to use shared helpers 
- Add more tests for IAM delete certificate idempotency
- Update IAM idempotency tests to use parameters for all service instance types

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just improving IAM certificate removal logic
