### PR TITLE
Remove old DNS records on update

### DIFF
--- a/broker/pipelines/alb.py
+++ b/broker/pipelines/alb.py
@@ -58,6 +58,7 @@ def queue_all_alb_update_tasks_for_operation(operation_id, correlation_id):
         .then(letsencrypt.initiate_challenges, operation_id, **correlation)
         .then(route53.create_TXT_records, operation_id, **correlation)
         .then(route53.wait_for_changes, operation_id, **correlation)
+        .then(route53.remove_old_DNS_records, operation_id, **correlation)
         .then(letsencrypt.answer_challenges, operation_id, **correlation)
         .then(letsencrypt.retrieve_certificate, operation_id, **correlation)
         .then(iam.upload_server_certificate, operation_id, **correlation)

--- a/broker/pipelines/cdn.py
+++ b/broker/pipelines/cdn.py
@@ -60,7 +60,7 @@ def queue_all_cdn_update_tasks_for_operation(operation_id, correlation_id):
         .then(letsencrypt.initiate_challenges, operation_id, **correlation)
         .then(route53.create_TXT_records, operation_id, **correlation)
         .then(route53.wait_for_changes, operation_id, **correlation)
-        .then(route53.remove_old_TXT_records, operation_id, **correlation)
+        .then(route53.remove_old_DNS_records, operation_id, **correlation)
         .then(letsencrypt.answer_challenges, operation_id, **correlation)
         .then(letsencrypt.retrieve_certificate, operation_id, **correlation)
         .then(iam.upload_server_certificate, operation_id, **correlation)

--- a/broker/pipelines/cdn.py
+++ b/broker/pipelines/cdn.py
@@ -60,6 +60,7 @@ def queue_all_cdn_update_tasks_for_operation(operation_id, correlation_id):
         .then(letsencrypt.initiate_challenges, operation_id, **correlation)
         .then(route53.create_TXT_records, operation_id, **correlation)
         .then(route53.wait_for_changes, operation_id, **correlation)
+        .then(route53.remove_old_TXT_records, operation_id, **correlation)
         .then(letsencrypt.answer_challenges, operation_id, **correlation)
         .then(letsencrypt.retrieve_certificate, operation_id, **correlation)
         .then(iam.upload_server_certificate, operation_id, **correlation)

--- a/broker/pipelines/cdn_dedicated_waf.py
+++ b/broker/pipelines/cdn_dedicated_waf.py
@@ -79,6 +79,7 @@ def queue_all_cdn_dedicated_waf_update_tasks_for_operation(
         .then(letsencrypt.initiate_challenges, operation_id, **correlation)
         .then(route53.create_TXT_records, operation_id, **correlation)
         .then(route53.wait_for_changes, operation_id, **correlation)
+        .then(route53.remove_old_TXT_records, operation_id, **correlation)
         .then(letsencrypt.answer_challenges, operation_id, **correlation)
         .then(letsencrypt.retrieve_certificate, operation_id, **correlation)
         .then(iam.upload_server_certificate, operation_id, **correlation)

--- a/broker/pipelines/cdn_dedicated_waf.py
+++ b/broker/pipelines/cdn_dedicated_waf.py
@@ -79,7 +79,7 @@ def queue_all_cdn_dedicated_waf_update_tasks_for_operation(
         .then(letsencrypt.initiate_challenges, operation_id, **correlation)
         .then(route53.create_TXT_records, operation_id, **correlation)
         .then(route53.wait_for_changes, operation_id, **correlation)
-        .then(route53.remove_old_TXT_records, operation_id, **correlation)
+        .then(route53.remove_old_DNS_records, operation_id, **correlation)
         .then(letsencrypt.answer_challenges, operation_id, **correlation)
         .then(letsencrypt.retrieve_certificate, operation_id, **correlation)
         .then(iam.upload_server_certificate, operation_id, **correlation)

--- a/broker/pipelines/dedicated_alb.py
+++ b/broker/pipelines/dedicated_alb.py
@@ -62,6 +62,7 @@ def queue_all_dedicated_alb_update_tasks_for_operation(operation_id, correlation
         .then(letsencrypt.initiate_challenges, operation_id, **correlation)
         .then(route53.create_TXT_records, operation_id, **correlation)
         .then(route53.wait_for_changes, operation_id, **correlation)
+        .then(route53.remove_old_DNS_records, operation_id, **correlation)
         .then(letsencrypt.answer_challenges, operation_id, **correlation)
         .then(letsencrypt.retrieve_certificate, operation_id, **correlation)
         .then(iam.upload_server_certificate, operation_id, **correlation)

--- a/broker/tasks/route53.py
+++ b/broker/tasks/route53.py
@@ -63,32 +63,7 @@ def remove_TXT_records(operation_id: int, **kwargs):
 
     for certificate in service_instance.certificates:
         for challenge in certificate.challenges:
-            domain = challenge.validation_domain
-            txt_record = f"{domain}.{config.DNS_ROOT_DOMAIN}"
-            contents = challenge.validation_contents
-            logger.info(f'Removing TXT record {txt_record} with contents "{contents}"')
-            try:
-                route53_response = route53.change_resource_record_sets(
-                    ChangeBatch={
-                        "Changes": [
-                            {
-                                "Action": "DELETE",
-                                "ResourceRecordSet": {
-                                    "Type": "TXT",
-                                    "Name": txt_record,
-                                    "ResourceRecords": [{"Value": f'"{contents}"'}],
-                                    "TTL": 60,
-                                },
-                            }
-                        ]
-                    },
-                    HostedZoneId=config.ROUTE53_ZONE_ID,
-                )
-            except:  # noqa E722
-                logger.info("Ignoring error because we don't care")
-            else:
-                change_id = route53_response["ChangeInfo"]["Id"]
-                logger.info(f"Ignoring Route53 TXT change ID: {change_id}")
+            _delete_TXT_record(challenge)
 
 
 @huey.retriable_task

--- a/tests/integration/alb/test_alb_order_status_mismatch.py
+++ b/tests/integration/alb/test_alb_order_status_mismatch.py
@@ -8,9 +8,7 @@ It doesn't matter that this test is on ALB - the same issue occurs for the same 
 instance type, but there's no need to test both cases.
 """
 
-import pytest
-import uuid
-from broker.extensions import config, db
+from broker.extensions import db
 from broker.models import ALBServiceInstance
 from broker.tasks.letsencrypt import retrieve_certificate
 
@@ -26,16 +24,6 @@ from tests.lib.alb.provision import (
     subtest_provision_creates_provision_operation,
     subtest_provision_retrieves_certificate,
 )
-
-
-@pytest.fixture
-def organization_guid():
-    return str(uuid.uuid4())
-
-
-@pytest.fixture
-def space_guid():
-    return str(uuid.uuid4())
 
 
 def test_stuff(client, dns, tasks, route53, organization_guid, space_guid):

--- a/tests/integration/alb/test_alb_provisioning.py
+++ b/tests/integration/alb/test_alb_provisioning.py
@@ -1,6 +1,3 @@
-import pytest  # noqa F401
-import uuid
-
 from broker.extensions import db
 from broker.models import ALBServiceInstance
 from broker.tasks.alb import get_lowest_used_alb
@@ -30,17 +27,6 @@ from tests.lib.alb.update import (
 from tests.integration.alb.test_alb_update import (
     subtest_update_happy_path,
 )
-
-
-@pytest.fixture
-def organization_guid():
-    return str(uuid.uuid4())
-
-
-@pytest.fixture
-def space_guid():
-    return str(uuid.uuid4())
-
 
 # The subtests below are "interesting".  Before test_provision_happy_path, we
 # had separate tests for each stage in the task pipeline.  But each test would

--- a/tests/integration/alb/test_alb_update.py
+++ b/tests/integration/alb/test_alb_update.py
@@ -21,6 +21,7 @@ from tests.lib.alb.update import (
     subtest_update_uploads_new_cert,
     subtest_update_provisions_ALIAS_records,
     subtest_removes_previous_certificate_from_alb,
+    subtest_update_removes_old_DNS_records,
 )
 
 
@@ -34,6 +35,7 @@ def subtest_update_happy_path(
     subtest_gets_new_challenges(tasks, instance_model)
     subtest_update_creates_new_TXT_records(tasks, route53, instance_model)
     subtest_waits_for_dns_changes(tasks, route53, instance_model)
+    subtest_update_removes_old_DNS_records(tasks, route53, instance_model)
     subtest_update_answers_challenges(tasks, dns, instance_model)
     subtest_update_retrieves_new_cert(tasks, instance_model)
     subtest_update_uploads_new_cert(tasks, iam_govcloud, simple_regex, instance_model)

--- a/tests/integration/alb/test_alb_update.py
+++ b/tests/integration/alb/test_alb_update.py
@@ -36,6 +36,9 @@ def subtest_update_happy_path(
     subtest_update_creates_new_TXT_records(tasks, route53, instance_model)
     subtest_waits_for_dns_changes(tasks, route53, instance_model)
     subtest_update_removes_old_DNS_records(tasks, route53, instance_model)
+    check_last_operation_description(
+        client, "4321", operation_id, "Removing old DNS records"
+    )
     subtest_update_answers_challenges(tasks, dns, instance_model)
     subtest_update_retrieves_new_cert(tasks, instance_model)
     subtest_update_uploads_new_cert(tasks, iam_govcloud, simple_regex, instance_model)

--- a/tests/integration/alb/test_alb_update.py
+++ b/tests/integration/alb/test_alb_update.py
@@ -10,7 +10,7 @@ from tests.lib.client import check_last_operation_description
 from tests.lib.update import (
     subtest_update_creates_private_key_and_csr,
     subtest_gets_new_challenges,
-    subtest_update_updates_TXT_records,
+    subtest_update_creates_new_TXT_records,
     subtest_update_answers_challenges,
     subtest_waits_for_dns_changes,
     subtest_update_retrieves_new_cert,
@@ -32,7 +32,7 @@ def subtest_update_happy_path(
     check_last_operation_description(client, "4321", operation_id, "Queuing tasks")
     subtest_update_creates_private_key_and_csr(tasks, instance_model)
     subtest_gets_new_challenges(tasks, instance_model)
-    subtest_update_updates_TXT_records(tasks, route53, instance_model)
+    subtest_update_creates_new_TXT_records(tasks, route53, instance_model)
     subtest_waits_for_dns_changes(tasks, route53, instance_model)
     subtest_update_answers_challenges(tasks, dns, instance_model)
     subtest_update_retrieves_new_cert(tasks, instance_model)

--- a/tests/integration/cdn_dedicated_waf/test_cdn_dedicated_waf_deprovisioning.py
+++ b/tests/integration/cdn_dedicated_waf/test_cdn_dedicated_waf_deprovisioning.py
@@ -1,5 +1,4 @@
 import pytest  # noqa F401
-import uuid
 
 from broker.extensions import db
 from broker.models import CDNDedicatedWAFServiceInstance
@@ -25,11 +24,6 @@ from tests.lib.deprovision import (
     subtest_deprovision_marks_operation_as_succeeded,
     subtest_deprovision_removes_certificate_from_iam_when_missing,
 )
-
-
-@pytest.fixture
-def protection_id():
-    return str(uuid.uuid4())
 
 
 @pytest.fixture

--- a/tests/integration/cdn_dedicated_waf/test_cdn_dedicated_waf_provisioning.py
+++ b/tests/integration/cdn_dedicated_waf/test_cdn_dedicated_waf_provisioning.py
@@ -32,7 +32,6 @@ from tests.lib.update import (
     subtest_update_retrieves_new_cert,
     subtest_update_marks_update_complete,
     subtest_update_removes_certificate_from_iam,
-    subtest_update_same_domains_does_not_update_route53,
 )
 from tests.lib.cdn.update import (
     subtest_update_creates_update_operation,
@@ -47,6 +46,7 @@ from tests.lib.cdn.update import (
     subtest_update_same_domains_updates_cloudfront,
     subtest_update_same_domains_does_not_delete_server_certificate,
     subtest_update_same_domains_does_not_create_new_challenges,
+    subtest_update_does_not_create_new_TXT_records,
 )
 from tests.integration.cdn_dedicated_waf.provision import (
     subtest_provision_create_web_acl,
@@ -270,7 +270,7 @@ def subtest_update_same_domains(
     subtest_update_same_domains_creates_update_operation(client, dns, instance_model)
     subtest_update_same_domains_does_not_create_new_certificate(tasks, instance_model)
     subtest_update_same_domains_does_not_create_new_challenges(tasks, instance_model)
-    subtest_update_same_domains_does_not_update_route53(tasks, route53, instance_model)
+    subtest_update_does_not_create_new_TXT_records(tasks, route53, instance_model)
     subtest_update_same_domains_does_not_retrieve_new_certificate(tasks)
     subtest_update_same_domains_does_not_update_iam(tasks)
     subtest_update_web_acl_does_not_update(tasks, wafv2)

--- a/tests/integration/cdn_dedicated_waf/test_cdn_dedicated_waf_provisioning.py
+++ b/tests/integration/cdn_dedicated_waf/test_cdn_dedicated_waf_provisioning.py
@@ -26,7 +26,7 @@ from tests.lib.cdn.provision import (
 from tests.lib.update import (
     subtest_update_creates_private_key_and_csr,
     subtest_gets_new_challenges,
-    subtest_update_updates_TXT_records,
+    subtest_update_creates_new_TXT_records,
     subtest_update_answers_challenges,
     subtest_waits_for_dns_changes,
     subtest_update_retrieves_new_cert,
@@ -225,7 +225,7 @@ def subtest_update_happy_path(
     check_last_operation_description(client, "4321", operation_id, "Queuing tasks")
     subtest_update_creates_private_key_and_csr(tasks, instance_model)
     subtest_gets_new_challenges(tasks, instance_model)
-    subtest_update_updates_TXT_records(tasks, route53, instance_model)
+    subtest_update_creates_new_TXT_records(tasks, route53, instance_model)
     subtest_waits_for_dns_changes(tasks, route53, instance_model)
     subtest_update_removes_old_TXT_records(tasks, route53, instance_model)
     check_last_operation_description(

--- a/tests/integration/cdn_dedicated_waf/test_cdn_dedicated_waf_provisioning.py
+++ b/tests/integration/cdn_dedicated_waf/test_cdn_dedicated_waf_provisioning.py
@@ -1,6 +1,3 @@
-import pytest  # noqa F401
-import uuid
-
 from broker.models import (
     CDNDedicatedWAFServiceInstance,
 )
@@ -66,16 +63,6 @@ from tests.integration.cdn_dedicated_waf.update import (
     subtest_updates_health_check_alarms,
     subtest_updates_health_check_alarms_no_change,
 )
-
-
-@pytest.fixture
-def organization_guid():
-    return str(uuid.uuid4())
-
-
-@pytest.fixture
-def space_guid():
-    return str(uuid.uuid4())
 
 
 # The subtests below are "interesting".  Before test_provision_happy_path, we

--- a/tests/integration/cdn_dedicated_waf/test_cdn_dedicated_waf_provisioning.py
+++ b/tests/integration/cdn_dedicated_waf/test_cdn_dedicated_waf_provisioning.py
@@ -32,7 +32,7 @@ from tests.lib.update import (
     subtest_update_retrieves_new_cert,
     subtest_update_marks_update_complete,
     subtest_update_removes_certificate_from_iam,
-    subtest_update_removes_old_TXT_records,
+    subtest_update_removes_old_DNS_records,
 )
 from tests.lib.cdn.update import (
     subtest_update_creates_update_operation,
@@ -227,9 +227,9 @@ def subtest_update_happy_path(
     subtest_gets_new_challenges(tasks, instance_model)
     subtest_update_creates_new_TXT_records(tasks, route53, instance_model)
     subtest_waits_for_dns_changes(tasks, route53, instance_model)
-    subtest_update_removes_old_TXT_records(tasks, route53, instance_model)
+    subtest_update_removes_old_DNS_records(tasks, route53, instance_model)
     check_last_operation_description(
-        client, "4321", operation_id, "Removing old DNS TXT records"
+        client, "4321", operation_id, "Removing old DNS records"
     )
     subtest_update_answers_challenges(tasks, dns, instance_model)
     subtest_update_retrieves_new_cert(tasks, instance_model)

--- a/tests/integration/cdn_dedicated_waf/test_cdn_dedicated_waf_provisioning.py
+++ b/tests/integration/cdn_dedicated_waf/test_cdn_dedicated_waf_provisioning.py
@@ -32,6 +32,7 @@ from tests.lib.update import (
     subtest_update_retrieves_new_cert,
     subtest_update_marks_update_complete,
     subtest_update_removes_certificate_from_iam,
+    subtest_update_removes_old_TXT_records,
 )
 from tests.lib.cdn.update import (
     subtest_update_creates_update_operation,
@@ -47,6 +48,7 @@ from tests.lib.cdn.update import (
     subtest_update_same_domains_does_not_delete_server_certificate,
     subtest_update_same_domains_does_not_create_new_challenges,
     subtest_update_does_not_create_new_TXT_records,
+    subtest_update_does_not_remove_old_TXT_records,
 )
 from tests.integration.cdn_dedicated_waf.provision import (
     subtest_provision_create_web_acl,
@@ -225,6 +227,10 @@ def subtest_update_happy_path(
     subtest_gets_new_challenges(tasks, instance_model)
     subtest_update_updates_TXT_records(tasks, route53, instance_model)
     subtest_waits_for_dns_changes(tasks, route53, instance_model)
+    subtest_update_removes_old_TXT_records(tasks, route53, instance_model)
+    check_last_operation_description(
+        client, "4321", operation_id, "Removing old DNS TXT records"
+    )
     subtest_update_answers_challenges(tasks, dns, instance_model)
     subtest_update_retrieves_new_cert(tasks, instance_model)
     subtest_update_uploads_new_cert(tasks, iam_commercial, simple_regex, instance_model)
@@ -271,6 +277,7 @@ def subtest_update_same_domains(
     subtest_update_same_domains_does_not_create_new_certificate(tasks, instance_model)
     subtest_update_same_domains_does_not_create_new_challenges(tasks, instance_model)
     subtest_update_does_not_create_new_TXT_records(tasks, route53, instance_model)
+    subtest_update_does_not_remove_old_TXT_records(tasks, route53)
     subtest_update_same_domains_does_not_retrieve_new_certificate(tasks)
     subtest_update_same_domains_does_not_update_iam(tasks)
     subtest_update_web_acl_does_not_update(tasks, wafv2)

--- a/tests/integration/cdn_dedicated_waf/test_cdn_dedicated_waf_provisioning.py
+++ b/tests/integration/cdn_dedicated_waf/test_cdn_dedicated_waf_provisioning.py
@@ -32,7 +32,6 @@ from tests.lib.update import (
     subtest_update_retrieves_new_cert,
     subtest_update_marks_update_complete,
     subtest_update_removes_certificate_from_iam,
-    subtest_update_removes_old_DNS_records,
 )
 from tests.lib.cdn.update import (
     subtest_update_creates_update_operation,
@@ -49,6 +48,7 @@ from tests.lib.cdn.update import (
     subtest_update_same_domains_does_not_create_new_challenges,
     subtest_update_does_not_create_new_TXT_records,
     subtest_update_does_not_remove_old_TXT_records,
+    subtest_update_removes_old_DNS_records,
 )
 from tests.integration.cdn_dedicated_waf.provision import (
     subtest_provision_create_web_acl,

--- a/tests/integration/dedicated_alb/test_dedicated_alb_provisioning.py
+++ b/tests/integration/dedicated_alb/test_dedicated_alb_provisioning.py
@@ -1,6 +1,3 @@
-import pytest  # noqa F401
-import uuid
-
 from broker.extensions import db
 from broker.models import (
     DedicatedALBServiceInstance,
@@ -30,17 +27,6 @@ from tests.lib.alb.update import (
 from tests.integration.dedicated_alb.test_dedicated_alb_update import (
     subtest_update_happy_path,
 )
-
-
-@pytest.fixture
-def organization_guid():
-    return str(uuid.uuid4())
-
-
-@pytest.fixture
-def space_guid():
-    return str(uuid.uuid4())
-
 
 # The subtests below are "interesting".  Before test_provision_happy_path, we
 # had separate tests for each stage in the task pipeline.  But each test would

--- a/tests/integration/dedicated_alb/test_dedicated_alb_renewals.py
+++ b/tests/integration/dedicated_alb/test_dedicated_alb_renewals.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 
 from acme.errors import ValidationError
 import pytest
-import uuid
 
 from broker.extensions import db
 from broker.models import Operation, DedicatedALBServiceInstance
@@ -38,11 +37,6 @@ from tests.lib.factories import (
     OperationFactory,
     CertificateFactory,
 )
-
-
-@pytest.fixture
-def organization_guid():
-    return str(uuid.uuid4())
 
 
 @pytest.fixture

--- a/tests/integration/dedicated_alb/test_dedicated_alb_update.py
+++ b/tests/integration/dedicated_alb/test_dedicated_alb_update.py
@@ -25,6 +25,7 @@ from tests.lib.alb.update import (
     subtest_update_uploads_new_cert,
     subtest_update_provisions_ALIAS_records,
     subtest_removes_previous_certificate_from_alb,
+    subtest_update_removes_old_DNS_records,
 )
 
 
@@ -38,6 +39,10 @@ def subtest_update_happy_path(
     subtest_gets_new_challenges(tasks, instance_model)
     subtest_update_creates_new_TXT_records(tasks, route53, instance_model)
     subtest_waits_for_dns_changes(tasks, route53, instance_model)
+    subtest_update_removes_old_DNS_records(tasks, route53, instance_model)
+    check_last_operation_description(
+        client, "4321", operation_id, "Removing old DNS records"
+    )
     subtest_update_answers_challenges(tasks, dns, instance_model)
     subtest_update_retrieves_new_cert(tasks, instance_model)
     subtest_update_uploads_new_cert(tasks, iam_govcloud, simple_regex, instance_model)

--- a/tests/integration/dedicated_alb/test_dedicated_alb_update.py
+++ b/tests/integration/dedicated_alb/test_dedicated_alb_update.py
@@ -14,7 +14,7 @@ from tests.lib.client import check_last_operation_description
 from tests.lib.update import (
     subtest_update_creates_private_key_and_csr,
     subtest_gets_new_challenges,
-    subtest_update_updates_TXT_records,
+    subtest_update_creates_new_TXT_records,
     subtest_update_answers_challenges,
     subtest_waits_for_dns_changes,
     subtest_update_retrieves_new_cert,
@@ -36,7 +36,7 @@ def subtest_update_happy_path(
     check_last_operation_description(client, "4321", operation_id, "Queuing tasks")
     subtest_update_creates_private_key_and_csr(tasks, instance_model)
     subtest_gets_new_challenges(tasks, instance_model)
-    subtest_update_updates_TXT_records(tasks, route53, instance_model)
+    subtest_update_creates_new_TXT_records(tasks, route53, instance_model)
     subtest_waits_for_dns_changes(tasks, route53, instance_model)
     subtest_update_answers_challenges(tasks, dns, instance_model)
     subtest_update_retrieves_new_cert(tasks, instance_model)

--- a/tests/integration/plan_updates/test_alb_update_to_dedicated_alb.py
+++ b/tests/integration/plan_updates/test_alb_update_to_dedicated_alb.py
@@ -1,5 +1,4 @@
 import pytest
-import uuid
 
 from broker.models import DedicatedALBServiceInstance
 
@@ -13,14 +12,6 @@ from tests.lib.provision import (
     subtest_provision_waits_for_route53_changes,
 )
 from tests.lib.alb.provision import subtest_provision_provisions_ALIAS_records
-from tests.lib.alb.update import (
-    subtest_removes_previous_certificate_from_alb,
-)
-
-
-@pytest.fixture
-def organization_guid():
-    return str(uuid.uuid4())
 
 
 @pytest.fixture

--- a/tests/integration/plan_updates/test_cdn_update_to_cdn_dedicated_waf.py
+++ b/tests/integration/plan_updates/test_cdn_update_to_cdn_dedicated_waf.py
@@ -23,7 +23,7 @@ from tests.lib.cdn.update import (
     subtest_update_does_not_create_new_TXT_records,
     subtest_update_creates_private_key_and_csr,
     subtest_gets_new_challenges,
-    subtest_update_updates_TXT_records,
+    subtest_update_creates_new_TXT_records,
     subtest_waits_for_dns_changes,
     subtest_update_answers_challenges,
     subtest_update_retrieves_new_cert,
@@ -177,7 +177,7 @@ def test_update_plan_and_domains(
     check_last_operation_description(client, "4321", operation_id, "Queuing tasks")
     subtest_update_creates_private_key_and_csr(tasks, instance_model)
     subtest_gets_new_challenges(tasks, instance_model)
-    subtest_update_updates_TXT_records(tasks, route53, instance_model)
+    subtest_update_creates_new_TXT_records(tasks, route53, instance_model)
     subtest_waits_for_dns_changes(tasks, route53, instance_model)
     subtest_update_answers_challenges(tasks, dns, instance_model)
     subtest_update_retrieves_new_cert(tasks, instance_model)

--- a/tests/integration/plan_updates/test_cdn_update_to_cdn_dedicated_waf.py
+++ b/tests/integration/plan_updates/test_cdn_update_to_cdn_dedicated_waf.py
@@ -20,7 +20,7 @@ from tests.lib.cdn.update import (
     subtest_update_same_domains_updates_cloudfront,
     subtest_update_same_domains_does_not_delete_server_certificate,
     subtest_update_same_domains_does_not_create_new_challenges,
-    subtest_update_same_domains_does_not_update_route53,
+    subtest_update_does_not_create_new_TXT_records,
     subtest_update_creates_private_key_and_csr,
     subtest_gets_new_challenges,
     subtest_update_updates_TXT_records,
@@ -87,7 +87,7 @@ def test_update_plan_only(
         instance_model,
     )
     subtest_update_same_domains_does_not_create_new_challenges(tasks, instance_model)
-    subtest_update_same_domains_does_not_update_route53(tasks, route53, instance_model)
+    subtest_update_does_not_create_new_TXT_records(tasks, route53, instance_model)
     subtest_update_same_domains_does_not_retrieve_new_certificate(tasks)
     subtest_update_same_domains_does_not_update_iam(tasks)
     subtest_provision_create_web_acl(tasks, wafv2)

--- a/tests/integration/test_route53.py
+++ b/tests/integration/test_route53.py
@@ -374,6 +374,17 @@ def test_route53_deletes_health_checks_unmigrated_cdn_dedicated_waf_instance(
     assert service_instance.route53_health_checks == None
 
 
+def test_route53_deletes_old_DNS_records_does_nothing(
+    clean_db, route53, service_instance_with_challenges, operation_id
+):
+    remove_old_DNS_records.call_local(operation_id)
+
+    route53.assert_no_pending_responses()
+
+    operation = clean_db.session.get(Operation, operation_id)
+    assert operation.step_description == "Removing old DNS records"
+
+
 def test_route53_deletes_old_DNS_records(
     clean_db, route53, service_instance_with_challenges, operation_id
 ):

--- a/tests/integration/test_route53.py
+++ b/tests/integration/test_route53.py
@@ -5,6 +5,7 @@ from broker.tasks.route53 import (
     create_new_health_checks,
     delete_unused_health_checks,
     delete_health_checks,
+    remove_old_DNS_records,
 )
 from broker.models import (
     CDNServiceInstance,
@@ -21,6 +22,8 @@ def service_instance(
     operation_id,
     service_instance_id,
     cloudfront_distribution_arn,
+    new_cert_id,
+    current_cert_id,
 ):
     service_instance = factories.CDNDedicatedWAFServiceInstanceFactory.create(
         id=service_instance_id,
@@ -41,13 +44,13 @@ def service_instance(
         iam_server_certificate_id="certificate_id",
         leaf_pem="SOMECERTPEM",
         fullchain_pem="FULLCHAINOFSOMECERTPEM",
-        id=1002,
+        id=new_cert_id,
     )
     current_cert = factories.CertificateFactory.create(
         service_instance=service_instance,
         private_key_pem="SOMEPRIVATEKEY",
         iam_server_certificate_id="certificate_id",
-        id=1001,
+        id=current_cert_id,
     )
     service_instance.current_certificate = current_cert
     service_instance.new_certificate = new_cert
@@ -58,6 +61,23 @@ def service_instance(
     clean_db.session.expunge_all()
     factories.OperationFactory.create(
         id=operation_id, service_instance=service_instance
+    )
+    return service_instance
+
+
+@pytest.fixture
+def service_instance_with_challenges(service_instance, current_cert_id):
+    factories.ChallengeFactory.create(
+        domain="example.com",
+        validation_contents="example txt",
+        certificate_id=current_cert_id,
+        answered=True,
+    )
+    factories.ChallengeFactory.create(
+        domain="foo.com",
+        validation_contents="foo txt",
+        certificate_id=current_cert_id,
+        answered=True,
     )
     return service_instance
 
@@ -352,3 +372,53 @@ def test_route53_deletes_health_checks_unmigrated_cdn_dedicated_waf_instance(
         CDNDedicatedWAFServiceInstance, service_instance_id
     )
     assert service_instance.route53_health_checks == None
+
+
+def test_route53_deletes_old_DNS_records(
+    clean_db, route53, service_instance_with_challenges, operation_id
+):
+    # simulate a change in domain names
+    service_instance_with_challenges.domain_names = ["bar.com", "cow.com"]
+
+    clean_db.session.add(service_instance_with_challenges)
+    clean_db.session.commit()
+
+    route53.expect_remove_TXT(
+        "_acme-challenge.example.com.domains.cloud.test", "example txt"
+    )
+    route53.expect_remove_ALIAS(
+        "example.com.domains.cloud.test", "fake1234.cloudfront.net"
+    )
+    route53.expect_remove_TXT("_acme-challenge.foo.com.domains.cloud.test", "foo txt")
+    route53.expect_remove_ALIAS("foo.com.domains.cloud.test", "fake1234.cloudfront.net")
+
+    remove_old_DNS_records.call_local(operation_id)
+
+    route53.assert_no_pending_responses()
+
+
+def test_route53_deletes_old_DNS_records_ignores_errors(
+    clean_db, route53, service_instance_with_challenges, operation_id
+):
+    # simulate a change in domain names
+    service_instance_with_challenges.domain_names = ["bar.com", "cow.com"]
+
+    clean_db.session.add(service_instance_with_challenges)
+    clean_db.session.commit()
+
+    # error should be ignored
+    route53.expect_remove_missing_TXT(
+        "_acme-challenge.example.com.domains.cloud.test", "example txt"
+    )
+    route53.expect_remove_ALIAS(
+        "example.com.domains.cloud.test", "fake1234.cloudfront.net"
+    )
+    route53.expect_remove_TXT("_acme-challenge.foo.com.domains.cloud.test", "foo txt")
+    # error should be ignored
+    route53.expect_remove_missing_ALIAS(
+        "foo.com.domains.cloud.test", "fake1234.cloudfront.net"
+    )
+
+    remove_old_DNS_records.call_local(operation_id)
+
+    route53.assert_no_pending_responses()

--- a/tests/lib/alb/update.py
+++ b/tests/lib/alb/update.py
@@ -65,3 +65,25 @@ def subtest_removes_previous_certificate_from_alb(
     tasks.run_queued_tasks_and_enqueue_dependents()
 
     alb.assert_no_pending_responses()
+
+
+def subtest_update_removes_old_DNS_records(
+    tasks, route53, instance_model, service_instance_id="4321"
+):
+    service_instance = db.session.get(instance_model, service_instance_id)
+    challenges = service_instance.current_certificate.challenges.all()
+    challenge = next(
+        (challenge for challenge in challenges if challenge.domain == "example.com"),
+        None,
+    )
+
+    route53.expect_remove_TXT(
+        "_acme-challenge.example.com.domains.cloud.test", challenge.validation_contents
+    )
+    route53.expect_remove_ALIAS(
+        "example.com.domains.cloud.test", "alb.cloud.test", "ALBHOSTEDZONEID"
+    )
+
+    tasks.run_queued_tasks_and_enqueue_dependents()
+
+    route53.assert_no_pending_responses()

--- a/tests/lib/cdn/update.py
+++ b/tests/lib/cdn/update.py
@@ -17,7 +17,6 @@ from tests.lib.update import (
     subtest_update_removes_certificate_from_iam,
     subtest_update_same_domains_does_not_update_iam,
     subtest_update_same_domains_does_not_retrieve_new_certificate,
-    subtest_update_removes_old_DNS_records,
 )
 
 

--- a/tests/lib/cdn/update.py
+++ b/tests/lib/cdn/update.py
@@ -9,7 +9,7 @@ from tests.lib.client import check_last_operation_description
 from tests.lib.update import (
     subtest_update_creates_private_key_and_csr,
     subtest_gets_new_challenges,
-    subtest_update_updates_TXT_records,
+    subtest_update_creates_new_TXT_records,
     subtest_update_answers_challenges,
     subtest_waits_for_dns_changes,
     subtest_update_retrieves_new_cert,
@@ -35,7 +35,7 @@ def subtest_update_happy_path(
     check_last_operation_description(client, "4321", operation_id, "Queuing tasks")
     subtest_update_creates_private_key_and_csr(tasks, instance_model)
     subtest_gets_new_challenges(tasks, instance_model)
-    subtest_update_updates_TXT_records(tasks, route53, instance_model)
+    subtest_update_creates_new_TXT_records(tasks, route53, instance_model)
     subtest_waits_for_dns_changes(tasks, route53, instance_model)
     subtest_update_removes_old_TXT_records(tasks, route53, instance_model)
     check_last_operation_description(

--- a/tests/lib/cdn/update.py
+++ b/tests/lib/cdn/update.py
@@ -17,7 +17,7 @@ from tests.lib.update import (
     subtest_update_removes_certificate_from_iam,
     subtest_update_same_domains_does_not_update_iam,
     subtest_update_same_domains_does_not_retrieve_new_certificate,
-    subtest_update_removes_old_TXT_records,
+    subtest_update_removes_old_DNS_records,
 )
 
 
@@ -37,9 +37,9 @@ def subtest_update_happy_path(
     subtest_gets_new_challenges(tasks, instance_model)
     subtest_update_creates_new_TXT_records(tasks, route53, instance_model)
     subtest_waits_for_dns_changes(tasks, route53, instance_model)
-    subtest_update_removes_old_TXT_records(tasks, route53, instance_model)
+    subtest_update_removes_old_DNS_records(tasks, route53, instance_model)
     check_last_operation_description(
-        client, "4321", operation_id, "Removing old DNS TXT records"
+        client, "4321", operation_id, "Removing old DNS records"
     )
     subtest_update_answers_challenges(tasks, dns, instance_model)
     subtest_update_retrieves_new_cert(tasks, instance_model)

--- a/tests/lib/cdn/update.py
+++ b/tests/lib/cdn/update.py
@@ -38,6 +38,9 @@ def subtest_update_happy_path(
     subtest_update_updates_TXT_records(tasks, route53, instance_model)
     subtest_waits_for_dns_changes(tasks, route53, instance_model)
     subtest_update_removes_old_TXT_records(tasks, route53, instance_model)
+    check_last_operation_description(
+        client, "4321", operation_id, "Removing old DNS TXT records"
+    )
     subtest_update_answers_challenges(tasks, dns, instance_model)
     subtest_update_retrieves_new_cert(tasks, instance_model)
     subtest_update_uploads_new_cert(tasks, iam_commercial, simple_regex, instance_model)

--- a/tests/lib/update.py
+++ b/tests/lib/update.py
@@ -55,29 +55,6 @@ def subtest_update_creates_new_TXT_records(
     assert service_instance.route53_change_ids == [bar_com_change_id, foo_com_change_id]
 
 
-def subtest_update_removes_old_DNS_records(
-    tasks, route53, instance_model, service_instance_id="4321"
-):
-    service_instance = db.session.get(instance_model, service_instance_id)
-
-    challenges = service_instance.current_certificate.challenges.all()
-    challenge = next(
-        (challenge for challenge in challenges if challenge.domain == "example.com"),
-        None,
-    )
-
-    route53.expect_remove_TXT(
-        "_acme-challenge.example.com.domains.cloud.test", challenge.validation_contents
-    )
-    route53.expect_remove_ALIAS(
-        "example.com.domains.cloud.test", "fake1234.cloudfront.net"
-    )
-
-    tasks.run_queued_tasks_and_enqueue_dependents()
-
-    route53.assert_no_pending_responses()
-
-
 def subtest_update_answers_challenges(
     tasks, dns, instance_model, service_instance_id="4321"
 ):

--- a/tests/lib/update.py
+++ b/tests/lib/update.py
@@ -55,7 +55,7 @@ def subtest_update_creates_new_TXT_records(
     assert service_instance.route53_change_ids == [bar_com_change_id, foo_com_change_id]
 
 
-def subtest_update_removes_old_TXT_records(
+def subtest_update_removes_old_DNS_records(
     tasks, route53, instance_model, service_instance_id="4321"
 ):
     service_instance = db.session.get(instance_model, service_instance_id)
@@ -68,6 +68,9 @@ def subtest_update_removes_old_TXT_records(
 
     route53.expect_remove_TXT(
         "_acme-challenge.example.com.domains.cloud.test", challenge.validation_contents
+    )
+    route53.expect_remove_ALIAS(
+        "example.com.domains.cloud.test", "fake1234.cloudfront.net"
     )
 
     tasks.run_queued_tasks_and_enqueue_dependents()

--- a/tests/lib/update.py
+++ b/tests/lib/update.py
@@ -37,7 +37,7 @@ def subtest_gets_new_challenges(tasks, instance_model, service_instance_id="4321
     )
 
 
-def subtest_update_updates_TXT_records(
+def subtest_update_creates_new_TXT_records(
     tasks, route53, instance_model, service_instance_id="4321"
 ):
     bar_com_change_id = route53.expect_create_TXT_and_return_change_id(


### PR DESCRIPTION
## Changes proposed in this pull request:

Fixes https://github.com/cloud-gov/external-domain-broker/issues/291

- Add `route53.remove_old_DNS_records` to remove TXT/ALIAS records in Route53 for domain names that are no longer active during an update operation
- Add `route53.remove_old_DNS_records` step to update pipelines for all service instances
- Add integration tests for `route53.remove_old_DNS_records` task
- Add step to integration tests of service update pipelines for `route53.remove_old_DNS_records`
- Clean up duplicate fixture declarations

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Should be none. Just making sure we clean up unnecessary DNS records in Route53 on update
