### PR TITLE
fix typo in acceptance tests run script

### DIFF
--- a/acceptance/run.sh
+++ b/acceptance/run.sh
@@ -154,7 +154,7 @@ tests() {
       "$PLAN_NAME" \
       "$INSTANCE" \
       -c "{\"domains\": \"$DOMAIN_0, $DOMAIN_1\", \"forward_cookies\": \"cookieone, cookietwo\", \"forward_headers\": \"x-one-header,x-two-header\", \"error_responses\": {\"404\": \"/errors/404.html\"}}"
-  elif [[ "${PLAN_NAME}" == "domain-with-cdn-dedicated-wafP" ]]; then
+  elif [[ "${PLAN_NAME}" == "domain-with-cdn-dedicated-waf" ]]; then
     echo "Creating the service instance"
     cf create-service \
       "$SERVICE_NAME" \


### PR DESCRIPTION
## Changes proposed in this pull request:

- see title

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing typo
