### PR TITLE
add unsubscribe step to update pipeline for CDN with dedicated WAF

### DIFF
--- a/broker/pipelines/cdn_dedicated_waf.py
+++ b/broker/pipelines/cdn_dedicated_waf.py
@@ -97,6 +97,7 @@ def queue_all_cdn_dedicated_waf_update_tasks_for_operation(
         .then(route53.wait_for_changes, operation_id, **correlation)
         .then(iam.delete_previous_server_certificate, operation_id, **correlation)
         .then(sns.create_notification_topic, operation_id, **correlation)
+        .then(sns.unsubscribe_notification_topic, operation_id, **correlation)
         .then(sns.subscribe_notification_topic, operation_id, **correlation)
         .then(route53.create_new_health_checks, operation_id, **correlation)
         .then(shield.update_associated_health_check, operation_id, **correlation)

--- a/tests/integration/cdn_dedicated_waf/deprovision.py
+++ b/tests/integration/cdn_dedicated_waf/deprovision.py
@@ -1,0 +1,15 @@
+from broker.extensions import db
+
+
+def subtest_deprovision_unsubscribe_sns_notification_topic(
+    instance_model, tasks, service_instance, sns_commercial, service_instance_id="1234"
+):
+    sns_commercial.expect_unsubscribe_topic(
+        service_instance.sns_notification_topic_subscription_arn
+    )
+
+    tasks.run_queued_tasks_and_enqueue_dependents()
+    sns_commercial.assert_no_pending_responses()
+
+    service_instance = db.session.get(instance_model, service_instance_id)
+    assert service_instance.sns_notification_topic_subscription_arn == None

--- a/tests/integration/cdn_dedicated_waf/test_cdn_dedicated_waf_provisioning.py
+++ b/tests/integration/cdn_dedicated_waf/test_cdn_dedicated_waf_provisioning.py
@@ -67,7 +67,7 @@ from tests.integration.cdn_dedicated_waf.update import (
     subtest_update_creates_health_check_alarms,
     subtest_update_does_not_create_sns_notification_topic,
     subtest_update_does_not_create_ddos_cloudwatch_alarm,
-    subtest_update_does_not_subscribe_sns_notification_topic,
+    subtest_update_unsubscribe_sns_notification_topic,
 )
 
 
@@ -258,7 +258,10 @@ def subtest_update_happy_path(
     subtest_update_does_not_create_sns_notification_topic(
         tasks, sns_commercial, instance_model
     )
-    subtest_update_does_not_subscribe_sns_notification_topic(
+    subtest_update_unsubscribe_sns_notification_topic(
+        tasks, sns_commercial, instance_model, service_instance_id="4321"
+    )
+    subtest_provision_subscribes_sns_notification_topic(
         tasks, sns_commercial, instance_model
     )
     subtest_update_creates_new_health_checks(tasks, route53, instance_model)
@@ -338,7 +341,10 @@ def subtest_update_same_domains(
     subtest_update_does_not_create_sns_notification_topic(
         tasks, sns_commercial, instance_model
     )
-    subtest_update_does_not_subscribe_sns_notification_topic(
+    subtest_update_unsubscribe_sns_notification_topic(
+        tasks, sns_commercial, instance_model, service_instance_id="4321"
+    )
+    subtest_provision_subscribes_sns_notification_topic(
         tasks, sns_commercial, instance_model
     )
     subtest_updates_health_checks_do_not_change(tasks, route53, instance_model)


### PR DESCRIPTION
## Changes proposed in this pull request:

- To ensure that the SNS email subscription is changed to the updated email anytime the service is updated, add a step for `unsubscribe_notification_topic` before `subscribe_notification_topic` in the update pipeline for CDN dedicated WAF instances

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just updating broker behavior
