### PR TITLE
Handle unsubscribe pending confirmation

### DIFF
--- a/broker/tasks/sns.py
+++ b/broker/tasks/sns.py
@@ -116,6 +116,16 @@ def unsubscribe_notification_topic(operation_id: int, *, operation, db, **kwargs
                     "subscription_arn": service_instance.sns_notification_topic_subscription_arn
                 },
             )
+        elif (
+            "InvalidParameter" in e.response["Error"]["Code"]
+            and "pending confirmation" in e.response["Error"]["Message"]
+        ):
+            logger.info(
+                "No need to unsubscribe, subscription still pending",
+                extra={
+                    "subscription_arn": service_instance.sns_notification_topic_subscription_arn
+                },
+            )
         else:
             logger.error(
                 f"Got this error code unsubscribing {service_instance.sns_notification_topic_subscription_arn}: {e.response['Error']}"

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -254,7 +254,7 @@ jobs:
       text: |
         :x: Testing FAILED for external-domain-broker
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: ((slack-failure-channel))
+      channel: ((slack-channel-customer-success))
       username: ((slack-username))
       icon_url: ((slack-icon-url))
 

--- a/tests/lib/fake_sns.py
+++ b/tests/lib/fake_sns.py
@@ -53,6 +53,15 @@ class FakeSNS(FakeAWS):
             expected_params={"SubscriptionArn": subscription_arn},
         )
 
+    def expect_unsubscribe_topic_still_pending(self, subscription_arn):
+        self.stubber.add_client_error(
+            "unsubscribe",
+            service_error_code="InvalidParameter",
+            service_message="Invalid parameter: SubscriptionArn Reason: Cannot unsubscribe a subscription that is pending confirmation",
+            http_status_code=400,
+            expected_params={"SubscriptionArn": subscription_arn},
+        )
+
     def expect_create_topic_subscription(
         self, topic_arn, alarm_notification_email, service_instance_id
     ):


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update `unsubscribe_notification_topic` to not throw error if the subscription is still pending confirmation and cannot be unsubscribed. This will fix failing integration tests where the subscription is never actually confirmed while the tests are running

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing broker behavior
