### PR TITLE
update requirement versions

### DIFF
--- a/pip-tools/dev-requirements.txt
+++ b/pip-tools/dev-requirements.txt
@@ -4,38 +4,42 @@
 #
 #    ./dev update-requirements
 #
-acme==2.11.0
+acme==3.0.1
     # via -r pip-tools/../requirements.txt
-alembic==1.13.2
+alembic==1.14.0
     # via
     #   -r pip-tools/../requirements.txt
     #   flask-migrate
-black==24.4.2
+async-timeout==5.0.1
+    # via
+    #   -r pip-tools/../requirements.txt
+    #   redis
+black==24.10.0
     # via -r pip-tools/dev-requirements.in
-blinker==1.8.2
+blinker==1.9.0
     # via
     #   -r pip-tools/../requirements.txt
     #   flask
-boto3==1.34.140
+boto3==1.35.63
     # via -r pip-tools/../requirements.txt
-botocore==1.34.140
+botocore==1.35.63
     # via
     #   -r pip-tools/../requirements.txt
     #   boto3
     #   s3transfer
-build==1.2.1
+build==1.2.2.post1
     # via pip-tools
-certifi==2024.7.4
+certifi==2024.8.30
     # via
     #   -r pip-tools/../requirements.txt
     #   requests
 cfenv==0.5.3
     # via -r pip-tools/../requirements.txt
-cffi==1.16.0
+cffi==1.17.1
     # via
     #   -r pip-tools/../requirements.txt
     #   cryptography
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via
     #   -r pip-tools/../requirements.txt
     #   requests
@@ -45,23 +49,23 @@ click==8.1.7
     #   black
     #   flask
     #   pip-tools
-cryptography==42.0.8
+cryptography==43.0.3
     # via
     #   -r pip-tools/../requirements.txt
     #   acme
     #   josepy
     #   pyopenssl
-dnspython==2.6.1
+dnspython==2.7.0
     # via -r pip-tools/../requirements.txt
-environs==11.0.0
+environs==11.2.0
     # via -r pip-tools/../requirements.txt
-factory-boy==3.3.0
+factory-boy==3.3.1
     # via -r pip-tools/dev-requirements.in
-faker==26.0.0
+faker==33.0.0
     # via factory-boy
-flake8==7.1.0
+flake8==7.1.1
     # via -r pip-tools/dev-requirements.in
-flask==3.0.3
+flask==3.1.0
     # via
     #   -r pip-tools/../requirements.txt
     #   flask-migrate
@@ -82,15 +86,15 @@ furl==2.1.3
     #   cfenv
 gprof2dot==2024.6.6
     # via pytest-profiling
-greenlet==3.0.3
+greenlet==3.1.1
     # via
     #   -r pip-tools/../requirements.txt
     #   sqlalchemy
-gunicorn==22.0.0
+gunicorn==23.0.0
     # via -r pip-tools/../requirements.txt
-huey==2.5.1
+huey==2.5.2
     # via -r pip-tools/../requirements.txt
-idna==3.7
+idna==3.10
     # via
     #   -r pip-tools/../requirements.txt
     #   requests
@@ -115,35 +119,35 @@ josepy==1.14.0
     # via
     #   -r pip-tools/../requirements.txt
     #   acme
-mako==1.3.5
+mako==1.3.6
     # via
     #   -r pip-tools/../requirements.txt
     #   alembic
-markupsafe==2.1.5
+markupsafe==3.0.2
     # via
     #   -r pip-tools/../requirements.txt
     #   jinja2
     #   mako
     #   werkzeug
-marshmallow==3.21.3
+marshmallow==3.23.1
     # via
     #   -r pip-tools/../requirements.txt
     #   environs
 mccabe==0.7.0
     # via flake8
-mypy==1.10.1
+mypy==1.13.0
     # via -r pip-tools/dev-requirements.in
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
-openbrokerapi==4.7.0
+openbrokerapi==4.7.1
     # via -r pip-tools/../requirements.txt
 orderedmultidict==1.0.1
     # via
     #   -r pip-tools/../requirements.txt
     #   furl
-packaging==24.1
+packaging==24.2
     # via
     #   -r pip-tools/../requirements.txt
     #   black
@@ -158,7 +162,7 @@ pathspec==0.12.1
     # via black
 pip-tools==7.4.1
     # via -r pip-tools/dev-requirements.in
-platformdirs==4.2.2
+platformdirs==4.3.6
     # via
     #   black
     #   pytoolconfig
@@ -170,9 +174,9 @@ pp-ez==0.2.0
     # via -r pip-tools/dev-requirements.in
 pprintpp==0.4.0
     # via -r pip-tools/dev-requirements.in
-psycopg2==2.9.9
+psycopg2==2.9.10
     # via -r pip-tools/../requirements.txt
-pycodestyle==2.12.0
+pycodestyle==2.12.1
     # via flake8
 pycparser==2.22
     # via
@@ -180,26 +184,26 @@ pycparser==2.22
     #   cffi
 pyflakes==3.2.0
     # via flake8
-pyopenssl==24.1.0
+pyopenssl==24.2.1
     # via
     #   -r pip-tools/../requirements.txt
     #   acme
     #   josepy
-pyproject-hooks==1.1.0
+pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pyrfc3339==1.1
+pyrfc3339==2.0.1
     # via
     #   -r pip-tools/../requirements.txt
     #   acme
-pytest==8.2.2
+pytest==8.3.3
     # via
     #   -r pip-tools/dev-requirements.in
     #   pytest-profiling
 pytest-profiling==1.7.0
     # via -r pip-tools/dev-requirements.in
-pytest-watcher==0.4.2
+pytest-watcher==0.4.3
     # via -r pip-tools/dev-requirements.in
 python-dateutil==2.9.0.post0
     # via
@@ -216,12 +220,11 @@ python-language-server==0.36.2
     # via -r pip-tools/dev-requirements.in
 pytoolconfig[global]==1.3.1
     # via rope
-pytz==2024.1
+pytz==2024.2
     # via
     #   -r pip-tools/../requirements.txt
     #   acme
-    #   pyrfc3339
-redis==5.0.7
+redis==5.2.0
     # via -r pip-tools/../requirements.txt
 requests==2.32.3
     # via
@@ -233,7 +236,7 @@ requests-mock==1.12.1
     # via -r pip-tools/dev-requirements.in
 rope==1.13.0
     # via -r pip-tools/dev-requirements.in
-s3transfer==0.10.2
+s3transfer==0.10.3
     # via
     #   -r pip-tools/../requirements.txt
     #   boto3
@@ -246,7 +249,7 @@ six==1.16.0
     #   orderedmultidict
     #   pytest-profiling
     #   python-dateutil
-sqlalchemy==2.0.31
+sqlalchemy==2.0.36
     # via
     #   -r pip-tools/../requirements.txt
     #   alembic
@@ -258,24 +261,25 @@ typing-extensions==4.12.2
     # via
     #   -r pip-tools/../requirements.txt
     #   alembic
+    #   faker
     #   mypy
     #   sqlalchemy
 ujson==5.10.0
     # via
     #   python-jsonrpc-server
     #   python-language-server
-urllib3==2.2.2
+urllib3==2.2.3
     # via
     #   -r pip-tools/../requirements.txt
     #   botocore
     #   requests
-watchdog==4.0.1
+watchdog==6.0.0
     # via pytest-watcher
-werkzeug==3.0.3
+werkzeug==3.1.3
     # via
     #   -r pip-tools/../requirements.txt
     #   flask
-wheel==0.43.0
+wheel==0.45.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,25 +4,27 @@
 #
 #    ./dev update-requirements
 #
-acme==2.11.0
+acme==3.0.1
     # via -r pip-tools/requirements.in
-alembic==1.13.2
+alembic==1.14.0
     # via flask-migrate
-blinker==1.8.2
+async-timeout==5.0.1
+    # via redis
+blinker==1.9.0
     # via flask
-boto3==1.34.140
+boto3==1.35.63
     # via -r pip-tools/requirements.in
-botocore==1.34.140
+botocore==1.35.63
     # via
     #   boto3
     #   s3transfer
-certifi==2024.7.4
+certifi==2024.8.30
     # via requests
 cfenv==0.5.3
     # via -r pip-tools/requirements.in
-cffi==1.16.0
+cffi==1.17.1
     # via cryptography
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
 click==8.1.7
     # via flask
@@ -31,11 +33,11 @@ cryptography==43.0.3
     #   acme
     #   josepy
     #   pyopenssl
-dnspython==2.6.1
+dnspython==2.7.0
     # via -r pip-tools/requirements.in
-environs==11.0.0
+environs==11.2.0
     # via -r pip-tools/requirements.in
-flask==3.0.3
+flask==3.1.0
     # via
     #   -r pip-tools/requirements.in
     #   flask-migrate
@@ -49,13 +51,13 @@ flask-sqlalchemy==3.1.1
     #   flask-migrate
 furl==2.1.3
     # via cfenv
-greenlet==3.0.3
+greenlet==3.1.1
     # via sqlalchemy
-gunicorn==22.0.0
+gunicorn==23.0.0
     # via -r pip-tools/requirements.in
-huey==2.5.1
+huey==2.5.2
     # via -r pip-tools/requirements.in
-idna==3.7
+idna==3.10
     # via requests
 itsdangerous==2.2.0
     # via flask
@@ -67,46 +69,44 @@ jmespath==1.0.1
     #   botocore
 josepy==1.14.0
     # via acme
-mako==1.3.5
+mako==1.3.6
     # via alembic
-markupsafe==2.1.5
+markupsafe==3.0.2
     # via
     #   jinja2
     #   mako
     #   werkzeug
-marshmallow==3.21.3
+marshmallow==3.23.1
     # via environs
-openbrokerapi==4.7.0
+openbrokerapi==4.7.1
     # via -r pip-tools/requirements.in
 orderedmultidict==1.0.1
     # via furl
-packaging==24.1
+packaging==24.2
     # via
     #   gunicorn
     #   marshmallow
-psycopg2==2.9.9
+psycopg2==2.9.10
     # via -r pip-tools/requirements.in
 pycparser==2.22
     # via cffi
-pyopenssl==24.1.0
+pyopenssl==24.2.1
     # via
     #   acme
     #   josepy
-pyrfc3339==1.1
+pyrfc3339==2.0.1
     # via acme
 python-dateutil==2.9.0.post0
     # via botocore
 python-dotenv==1.0.1
     # via environs
-pytz==2024.1
-    # via
-    #   acme
-    #   pyrfc3339
-redis==5.0.7
+pytz==2024.2
+    # via acme
+redis==5.2.0
     # via -r pip-tools/requirements.in
 requests==2.32.3
     # via acme
-s3transfer==0.10.2
+s3transfer==0.10.3
     # via boto3
 sap-cf-logging==4.2.7
     # via -r pip-tools/requirements.in
@@ -115,7 +115,7 @@ six==1.16.0
     #   furl
     #   orderedmultidict
     #   python-dateutil
-sqlalchemy==2.0.31
+sqlalchemy==2.0.36
     # via
     #   -r pip-tools/requirements.in
     #   alembic
@@ -127,7 +127,7 @@ typing-extensions==4.12.2
     # via
     #   alembic
     #   sqlalchemy
-urllib3==2.2.2
+urllib3==2.2.3
     # via
     #   botocore
     #   requests


### PR DESCRIPTION
## Changes proposed in this pull request:

After #399, we see this error in CI:

```
   The conflict is caused by:
   The user requested cryptography==43.0.3
   acme 2.11.0 depends on cryptography>=3.2.1
   josepy 1.14.0 depends on cryptography>=1.5
   pyopenssl 24.1.0 depends on cryptography<43 and >=41.0.5
```

This PR updates all requirements, hopefully fixing this error.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Updating dependencies gives us the latest fixes and security patches
