### PR TITLE
add missing env var for config unit tests

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -121,6 +121,9 @@ def mocked_env(
     monkeypatch.setenv("UAA_BASE_URL", "mock://uaa")
     monkeypatch.setenv("UAA_CLIENT_ID", uaa_client_id)
     monkeypatch.setenv("UAA_CLIENT_SECRET", uaa_client_secret)
+    monkeypatch.setenv(
+        "WAF_CLOUDWATCH_LOG_GROUP_ARN", "fake-waf-cloudwatch-log-group-arn"
+    )
 
 
 @pytest.mark.parametrize("env", ["production", "staging", "development"])


### PR DESCRIPTION
## Changes proposed in this pull request:

- see title

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing unit tests
