### PR TITLE
revert updates to crytogrpahy and pyopenssl

### DIFF
--- a/pip-tools/dev-requirements.txt
+++ b/pip-tools/dev-requirements.txt
@@ -49,7 +49,7 @@ click==8.1.7
     #   black
     #   flask
     #   pip-tools
-cryptography==43.0.3
+cryptography==42.0.8
     # via
     #   -r pip-tools/../requirements.txt
     #   acme
@@ -184,7 +184,7 @@ pycparser==2.22
     #   cffi
 pyflakes==3.2.0
     # via flake8
-pyopenssl==24.2.1
+pyopenssl==24.1.0
     # via
     #   -r pip-tools/../requirements.txt
     #   acme

--- a/pip-tools/requirements.in
+++ b/pip-tools/requirements.in
@@ -2,6 +2,9 @@ Flask-Migrate
 Flask-SQLAlchemy>3
 flask
 sqlalchemy
+# see https://github.com/certbot/josepy/issues/181
+cryptography<43
+pyopenssl<24.2.1
 acme
 boto3
 cfenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,8 +28,9 @@ charset-normalizer==3.4.0
     # via requests
 click==8.1.7
     # via flask
-cryptography==43.0.3
+cryptography==42.0.8
     # via
+    #   -r pip-tools/requirements.in
     #   acme
     #   josepy
     #   pyopenssl
@@ -90,8 +91,9 @@ psycopg2==2.9.10
     # via -r pip-tools/requirements.in
 pycparser==2.22
     # via cffi
-pyopenssl==24.2.1
+pyopenssl==24.1.0
     # via
+    #   -r pip-tools/requirements.in
     #   acme
     #   josepy
 pyrfc3339==2.0.1


### PR DESCRIPTION
## Changes proposed in this pull request:

We cannot upgrade to `cryptography > 43` at this time because:

- pyca/cryptography has vulnerabilities for >= 37.0.0, < 43.0.1
- [pyopenssl doesn't support cryptography > 43 until version 24.2.0](https://github.com/pyca/pyopenssl/blob/24.2.1/setup.py#L96)
- [pyopenssl 24.2.0 deprecates X509Req](https://github.com/certbot/josepy/issues/181), which we need, otherwise we get these errors

```
 DeprecationWarning: CSR support in pyOpenSSL is deprecated. You should use the APIs in cryptography.
```

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

We are rolling back to a version of `cryptography` with known security alerts, but we have no choice until https://github.com/certbot/josepy/issues/181 is resolved, which will happen when https://github.com/certbot/josepy/pull/182 is merged.

