### PR TITLE
ignore deprecation warnings from updated packages

### DIFF
--- a/pip-tools/requirements.in
+++ b/pip-tools/requirements.in
@@ -2,6 +2,9 @@ Flask-Migrate
 Flask-SQLAlchemy>3
 flask
 sqlalchemy
+# Josepy 2+ may introduce backward incompatible changes by droping usage of
+# deprecated PyOpenSSL APIs.
+josepy<2
 acme
 boto3
 cfenv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,5 +31,6 @@ ignore_patterns = ["venv/*", ".venv/*"]
 addopts = ["-vv"]
 filterwarnings = [
   'error',
-  'ignore:X509Extension support in pyOpenSSL is deprecated. You should use the APIs in cryptography.:DeprecationWarning'
+  'ignore:X509Extension support in pyOpenSSL is deprecated. You should use the APIs in cryptography.:DeprecationWarning',
+  'ignore:CSR support in pyOpenSSL is deprecated:DeprecationWarning'
 ]


### PR DESCRIPTION
## Changes proposed in this pull request:

We have upgraded to `cryptography > 43` because `pyca/cryptography` has vulnerabilities for >= 37.0.0, < 43.0.1

To upgrade `cryptography`, we had to update `pyopenssl`, since [pyopenssl doesn't support cryptography > 43 until version 24.2.0](https://github.com/pyca/pyopenssl/blob/24.2.1/setup.py#L96).

However, [pyopenssl 24.2.0 deprecates X509Req](https://github.com/certbot/josepy/issues/181), which leads to these errors:

```
DeprecationWarning: CSR support in pyOpenSSL is deprecated. You should use the APIs in cryptography.
```

This issue is noted in https://github.com/certbot/josepy/issues/181 and discussed in https://github.com/certbot/josepy/issues/182.

Unfortunately, there is no clear fix for this issue right now. The maintainers of josepy are considering abandoning it for a new library, but there is no timeline on that change: https://github.com/certbot/certbot/issues/8322

However, it seems like it is safe to ignore these warnings as long as we don't upgrade to josepy 2.x, as discussed in https://github.com/certbot/certbot/pull/9993.

This PR ignores the deprecation warning and adds a version constraint to ensure that we don't upgrade to josepy 2.x


## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Ignoring the deprecation warnings allows us to stay on newer package versions, which include patches for known security issues
