### PR TITLE
allow updating instances that reference cache policy ids

### DIFF
--- a/broker/tasks/cloudfront.py
+++ b/broker/tasks/cloudfront.py
@@ -304,12 +304,16 @@ def update_distribution(operation_id: str, *, operation, db, **kwargs):
     config["Origins"]["Items"][0]["CustomOriginConfig"][
         "OriginProtocolPolicy"
     ] = service_instance.origin_protocol_policy
-    config["DefaultCacheBehavior"]["ForwardedValues"]["Cookies"] = get_cookie_policy(
-        service_instance
-    )
-    config["DefaultCacheBehavior"]["ForwardedValues"]["Headers"] = get_header_policy(
-        service_instance
-    )
+    if "CachePolicyId" in config["DefaultCacheBehavior"]:
+        # handle cache policy id
+        pass
+    else:
+        config["DefaultCacheBehavior"]["ForwardedValues"]["Cookies"] = (
+            get_cookie_policy(service_instance)
+        )
+        config["DefaultCacheBehavior"]["ForwardedValues"]["Headers"] = (
+            get_header_policy(service_instance)
+        )
     config["Aliases"] = get_aliases(service_instance)
     config["CustomErrorResponses"] = get_custom_error_responses(service_instance)
 

--- a/broker/tasks/cloudfront.py
+++ b/broker/tasks/cloudfront.py
@@ -34,6 +34,12 @@ def get_header_policy(service_instance):
     }
 
 
+def has_default_cookie_and_header_policies(service_instance):
+    default_cookie_policy = {"Forward": "all"}
+    default_header_policy = {"Quantity": 0, "Items": []}
+    return all((default_cookie_policy == get_cookie_policy(service_instance), default_header_policy == get_header_policy(service_instance),))
+
+
 def get_aliases(service_instance):
     return {
         "Quantity": len(service_instance.domain_names),
@@ -305,8 +311,10 @@ def update_distribution(operation_id: str, *, operation, db, **kwargs):
         "OriginProtocolPolicy"
     ] = service_instance.origin_protocol_policy
     if "CachePolicyId" in config["DefaultCacheBehavior"]:
-        # handle cache policy id
-        pass
+        if not has_default_cookie_and_header_policies(service_instance):
+            # N.B. This is a really limited workaround. *currently* the only cache policy
+            # we're referencing uses 
+            raise NotImplementedError("Can't set non-default policy with cache-policy ID")
     else:
         config["DefaultCacheBehavior"]["ForwardedValues"]["Cookies"] = (
             get_cookie_policy(service_instance)

--- a/migrations/versions/8cb1ecea6207_add_all_initial_tables.py
+++ b/migrations/versions/8cb1ecea6207_add_all_initial_tables.py
@@ -1,7 +1,7 @@
 """add all initial tables
 
 Revision ID: 8cb1ecea6207
-Revises: 
+Revises:
 Create Date: 2020-06-04 20:51:39.664779
 
 """

--- a/tests/integration/alb/test_alb_check_duplicate_certs.py
+++ b/tests/integration/alb/test_alb_check_duplicate_certs.py
@@ -79,7 +79,12 @@ def test_no_service_duplicate_alb_certs(no_context_clean_db, no_context_app):
 
         no_context_clean_db.session.commit()
 
-        assert get_service_duplicate_alb_cert_count(service_instance.id, ALBServiceInstance) == 0
+        assert (
+            get_service_duplicate_alb_cert_count(
+                service_instance.id, ALBServiceInstance
+            )
+            == 0
+        )
 
 
 def test_service_duplicate_alb_certs(no_context_clean_db, no_context_app):
@@ -95,7 +100,12 @@ def test_service_duplicate_alb_certs(no_context_clean_db, no_context_app):
 
         no_context_clean_db.session.commit()
 
-        assert get_service_duplicate_alb_cert_count(service_instance.id, ALBServiceInstance) == 1
+        assert (
+            get_service_duplicate_alb_cert_count(
+                service_instance.id, ALBServiceInstance
+            )
+            == 1
+        )
 
 
 def test_service_duplicate_alb_certs_output(no_context_clean_db, no_context_app):

--- a/tests/integration/cdn/test_cdn_updates.py
+++ b/tests/integration/cdn/test_cdn_updates.py
@@ -1,0 +1,108 @@
+import pytest
+
+from broker.models import CDNServiceInstance
+from broker.tasks import cloudfront as cloudfront_tasks
+
+from tests.lib import factories
+
+
+@pytest.fixture
+def cdn_instance_ready_for_update(clean_db):
+    """
+    a cdn instance that looks like one we'd update.
+    We should test in the happy-path test that it looks reasonable/realistic.
+    """
+    service_instance = factories.CDNServiceInstanceFactory.create(
+        id="started-as-cdn-instance",
+        domain_names=["example.com", "foo.com"],
+        domain_internal="fake1234.cloudfront.net",
+        route53_alias_hosted_zone="Z2FDTNDATAQYW2",
+        cloudfront_distribution_id="FakeDistributionId",
+        cloudfront_origin_hostname="newer-origin.com",
+        cloudfront_origin_path="/somewhere-else",
+        origin_protocol_policy="https-only",
+    )
+    service_instance.new_certificate = factories.CertificateFactory.create(
+        id="1",
+        service_instance_id="started-as-cdn-instance",
+        iam_server_certificate_id="a-certificate-id",
+    )
+    clean_db.session.add(service_instance)
+    clean_db.session.add(service_instance.new_certificate)
+    clean_db.session.commit()
+    return service_instance
+
+
+def test_update_with_new_style_response(
+    clean_db, cdn_instance_ready_for_update, cloudfront
+):
+    # create the operation
+    service_instance_id = "started-as-cdn-instance"
+    operation = factories.OperationFactory.create(
+        id="1", service_instance=cdn_instance_ready_for_update, action="Update"
+    )
+    clean_db.session.add(operation)
+    clean_db.session.commit()
+    expect_update_domain_names = ["example.com", "foo.com"]
+    expect_origin_hostname = "newer-origin.com"
+    expect_origin_path = "/somewhere-else"
+    expect_forward_cookie_policy = (
+        CDNServiceInstance.ForwardCookiePolicy.WHITELIST.value
+    )
+    expect_origin_protocol_policy = "https-only"
+    expect_custom_error_responses = {"Quantity": 0}
+
+    clean_db.session.expunge_all()
+    service_instance = clean_db.session.get(CDNServiceInstance, service_instance_id)
+    certificate = service_instance.new_certificate
+    id_ = certificate.id
+    cloudfront.expect_get_distribution_config_returning_cache_behavior_id(
+        caller_reference=service_instance_id,
+        domains=["example.com", "foo.com"],
+        certificate_id=service_instance.new_certificate.iam_server_certificate_id,
+        origin_hostname="origin_hostname",
+        origin_path="origin_path",
+        distribution_id="FakeDistributionId",
+        bucket_prefix="4321/",
+        cache_policy_id="my-cache-policy",
+        origin_request_policy_id="my-origin-policy",
+        custom_error_responses={
+            "Quantity": 2,
+            "Items": [
+                {
+                    "ErrorCode": 404,
+                    "ResponsePagePath": "/errors/404.html",
+                    "ResponseCode": "404",
+                    "ErrorCachingMinTTL": 300,
+                },
+                {
+                    "ErrorCode": 405,
+                    "ResponsePagePath": "/errors/405.html",
+                    "ResponseCode": "405",
+                    "ErrorCachingMinTTL": 300,
+                },
+            ],
+        },
+    )
+    cloudfront.expect_update_distribution_with_cache_policy_id(
+        caller_reference=service_instance_id,
+        domains=expect_update_domain_names,
+        certificate_id=certificate.iam_server_certificate_id,
+        origin_hostname=expect_origin_hostname,
+        origin_path=expect_origin_path,
+        distribution_id="FakeDistributionId",
+        distribution_hostname="fake1234.cloudfront.net",
+        origin_protocol_policy=expect_origin_protocol_policy,
+        bucket_prefix="4321/",
+        custom_error_responses=expect_custom_error_responses,
+        cache_policy_id="my-cache-policy",
+        origin_request_policy_id="my-origin-policy",
+    )
+
+    cloudfront_tasks.update_distribution.call_local("1")
+    clean_db.session.expunge_all()
+
+    service_instance = clean_db.session.get(CDNServiceInstance, service_instance_id)
+    cloudfront.assert_no_pending_responses()
+    assert service_instance.new_certificate is None
+    assert service_instance.current_certificate.id == id_

--- a/tests/integration/dedicated_alb/test_dedicated_alb_check_duplicate_certs.py
+++ b/tests/integration/dedicated_alb/test_dedicated_alb_check_duplicate_certs.py
@@ -79,7 +79,12 @@ def test_no_service_duplicate_alb_certs(no_context_clean_db, no_context_app):
 
         no_context_clean_db.session.commit()
 
-        assert get_service_duplicate_alb_cert_count(service_instance.id, DedicatedALBServiceInstance) == 0
+        assert (
+            get_service_duplicate_alb_cert_count(
+                service_instance.id, DedicatedALBServiceInstance
+            )
+            == 0
+        )
 
 
 def test_service_duplicate_alb_certs(no_context_clean_db, no_context_app):
@@ -95,7 +100,12 @@ def test_service_duplicate_alb_certs(no_context_clean_db, no_context_app):
 
         no_context_clean_db.session.commit()
 
-        assert get_service_duplicate_alb_cert_count(service_instance.id, DedicatedALBServiceInstance) == 1
+        assert (
+            get_service_duplicate_alb_cert_count(
+                service_instance.id, DedicatedALBServiceInstance
+            )
+            == 1
+        )
 
 
 def test_service_duplicate_alb_certs_output(no_context_clean_db, no_context_app):


### PR DESCRIPTION
## Changes proposed in this pull request:

- allow updating instances that reference cache policy ids


## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None - this doesn't change the security posture of this app or the instances it touches.