### PR TITLE
update check for default forwarded headers to expect HOST

### DIFF
--- a/broker/tasks/cloudfront.py
+++ b/broker/tasks/cloudfront.py
@@ -36,8 +36,13 @@ def get_header_policy(service_instance):
 
 def has_default_cookie_and_header_policies(service_instance):
     default_cookie_policy = {"Forward": "all"}
-    default_header_policy = {"Quantity": 0, "Items": []}
-    return all((default_cookie_policy == get_cookie_policy(service_instance), default_header_policy == get_header_policy(service_instance),))
+    default_header_policy = {"Quantity": 1, "Items": ["HOST"]}
+    return all(
+        (
+            default_cookie_policy == get_cookie_policy(service_instance),
+            default_header_policy == get_header_policy(service_instance),
+        )
+    )
 
 
 def get_aliases(service_instance):
@@ -313,8 +318,10 @@ def update_distribution(operation_id: str, *, operation, db, **kwargs):
     if "CachePolicyId" in config["DefaultCacheBehavior"]:
         if not has_default_cookie_and_header_policies(service_instance):
             # N.B. This is a really limited workaround. *currently* the only cache policy
-            # we're referencing uses 
-            raise NotImplementedError("Can't set non-default policy with cache-policy ID")
+            # we're referencing uses
+            raise NotImplementedError(
+                "Can't set non-default policy with cache-policy ID"
+            )
     else:
         config["DefaultCacheBehavior"]["ForwardedValues"]["Cookies"] = (
             get_cookie_policy(service_instance)

--- a/tests/integration/cdn/test_cdn_updates.py
+++ b/tests/integration/cdn/test_cdn_updates.py
@@ -21,6 +21,7 @@ def cdn_instance_ready_for_update(clean_db):
         cloudfront_origin_hostname="newer-origin.com",
         cloudfront_origin_path="/somewhere-else",
         origin_protocol_policy="https-only",
+        forwarded_headers=["HOST"],
     )
     service_instance.new_certificate = factories.CertificateFactory.create(
         id="1",


### PR DESCRIPTION
## Changes proposed in this pull request:

Addresses #405 
Follow-up to #407 

It turns out that the default value for `forwarded_headers` on CDNs is `["HOST"]`: https://github.com/cloud-gov/external-domain-broker/blob/main/broker/api.py#L462

So for cases of CDNs that may have a custom `CachePolicyId`, but have `forwarded_headers: ["HOST"]`, we need to update the checks so that their updates can go through and continue using a custom cache policy.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

No direct security implications, just allowing CDN updates to proceed for CDNs with custom cache policies
