### PR TITLE
update update_associated_health_check task logic

### DIFF
--- a/broker/tasks/shield.py
+++ b/broker/tasks/shield.py
@@ -46,16 +46,20 @@ def update_associated_health_check(operation_id: int, *, operation, db, **kwargs
         f'Updating associated health check(s) for "{service_instance.domain_names}"'
     )
 
-    shield_associated_health_check_domain_name = (
-        service_instance.shield_associated_health_check["domain_name"]
-    )
+    if service_instance.shield_associated_health_check:
+        shield_associated_health_check_domain_name = (
+            service_instance.shield_associated_health_check["domain_name"]
+        )
 
-    # IF the domain name for associated health check is NOT IN the list of domain names,
-    # THEN it needs to be DISASSOCIATED
-    if shield_associated_health_check_domain_name not in service_instance.domain_names:
-        _disassociate_health_check(service_instance.shield_associated_health_check)
-        service_instance.shield_associated_health_check = None
-        flag_modified(service_instance, "shield_associated_health_check")
+        # IF the domain name for associated health check is NOT IN the list of domain names,
+        # THEN it needs to be DISASSOCIATED
+        if (
+            shield_associated_health_check_domain_name
+            not in service_instance.domain_names
+        ):
+            _disassociate_health_check(service_instance.shield_associated_health_check)
+            service_instance.shield_associated_health_check = None
+            flag_modified(service_instance, "shield_associated_health_check")
 
     # IF the domain name for associated health check is IN the list of domain names
     # AND there is not already an existing associated health check,

--- a/tests/integration/tasks/test_shield.py
+++ b/tests/integration/tasks/test_shield.py
@@ -133,6 +133,41 @@ def test_shield_associate_health_check_unmigrated_cdn_instance(
     }
 
 
+def test_shield_update_no_existing_associated_health_check(
+    clean_db,
+    protection_id,
+    protection,
+    service_instance_id,
+    service_instance,
+    operation_id,
+    shield,
+):
+    service_instance.shield_associated_health_check = {}
+
+    clean_db.session.add(service_instance)
+    clean_db.session.commit()
+    clean_db.session.expunge_all()
+
+    shield.expect_list_protections([protection])
+    shield.expect_associate_health_check(protection_id, "example.com ID")
+
+    update_associated_health_check.call_local(operation_id)
+
+    # There should be no calls to associate or disassociate a health check with Shield
+    shield.assert_no_pending_responses()
+
+    service_instance = clean_db.session.get(
+        CDNDedicatedWAFServiceInstance, service_instance_id
+    )
+    assert service_instance.shield_associated_health_check == {
+        "domain_name": "example.com",
+        "health_check_id": "example.com ID",
+        "protection_id": protection_id,
+    }
+    operation = clean_db.session.get(Operation, operation_id)
+    assert operation.step_description == "Updating associated health check with Shield"
+
+
 def test_shield_update_no_change_associated_health_check(
     clean_db, protection_id, service_instance_id, service_instance, operation_id, shield
 ):


### PR DESCRIPTION
## Changes proposed in this pull request:

- update update_associated_health_check task to handle case where no associated health check yet exists

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing a bug in the task logic
