### PR TITLE
Fix CDN update distribution logic

### DIFF
--- a/broker/lib/tags.py
+++ b/broker/lib/tags.py
@@ -55,7 +55,7 @@ def generate_instance_tags(
 def create_resource_tags(tags: dict[str, str]) -> list[Tag]:
     resource_tags = []
     for tag_key, tag_value in tags.items():
-        resource_tags = add_tag(resource_tags, tag_key, tag_value)
+        resource_tags = add_tag(resource_tags, {"Key": tag_key, "Value": tag_value})
     return resource_tags
 
 

--- a/broker/lib/tags.py
+++ b/broker/lib/tags.py
@@ -22,17 +22,16 @@ class Tag(typing.TypedDict):
     Value: str
 
 
-def add_tag(tags: list[Tag], tag_key: str, tag_value: str) -> list[Tag]:
+def tag_key_exists(tags: list[Tag], tag_key: str) -> bool:
+    return tag_key in [tag["Key"] for tag in tags]
+
+
+def add_tag(tags: list[Tag], tag: Tag) -> list[Tag]:
     if not tags:
         tags = []
-    if tag_key in [tag["Key"] for tag in tags]:
-        raise RuntimeError(f"Tag value already exists for {tag_key}")
-    tags.append(
-        {
-            "Key": tag_key,
-            "Value": tag_value,
-        }
-    )
+    if tag_key_exists(tags, tag["Key"]):
+        raise RuntimeError(f"Tag value already exists for {tag['Key']}")
+    tags.append(tag)
     return tags
 
 

--- a/broker/models.py
+++ b/broker/models.py
@@ -13,6 +13,7 @@ from sqlalchemy_utils.types.encrypted.encrypted_type import (
 )
 from openbrokerapi.service_broker import OperationState
 
+from broker.lib.tags import tag_key_exists, add_tag
 from broker.extensions import config, db
 
 
@@ -200,6 +201,16 @@ class CDNDedicatedWAFServiceInstance(CDNServiceInstance):
     __mapper_args__ = {
         "polymorphic_identity": ServiceInstanceTypes.CDN_DEDICATED_WAF.value
     }
+
+    def add_dedicated_web_acl_tag(self):
+        tags = self.tags if self.tags else []
+        has_dedicated_web_acl_tag = {"Key": "has_dedicated_acl", "Value": "true"}
+        if not tag_key_exists(tags, has_dedicated_web_acl_tag["Key"]):
+            tags = add_tag(
+                tags,
+                has_dedicated_web_acl_tag,
+            )
+        self.tags = tags
 
     def __repr__(self):
         return f"<CDNDedicatedWAFServiceInstance {self.id} {self.domain_names}>"

--- a/broker/tasks/cloudfront.py
+++ b/broker/tasks/cloudfront.py
@@ -79,7 +79,6 @@ def is_cdn_with_dedicated_waf_instance(service_instance) -> bool:
 
 
 def update_cdn_with_dedicated_waf_instance_tags(tags: list[Tag]) -> list[Tag]:
-    # tags = service_instance.tags if service_instance.tags else []
     tags = add_tag(tags, "has_dedicated_acl", "true")
     return tags
 

--- a/broker/tasks/cloudfront.py
+++ b/broker/tasks/cloudfront.py
@@ -3,7 +3,6 @@ import time
 
 from broker.aws import cloudfront
 from broker.extensions import config
-from broker.lib.tags import add_tag, Tag
 from broker.models import CDNServiceInstance, CDNDedicatedWAFServiceInstance
 from broker.tasks.huey import pipeline_operation
 
@@ -76,11 +75,6 @@ def is_cdn_with_dedicated_waf_instance(service_instance) -> bool:
         isinstance(service_instance, CDNDedicatedWAFServiceInstance)
         and service_instance.dedicated_waf_web_acl_arn
     )
-
-
-def update_cdn_with_dedicated_waf_instance_tags(tags: list[Tag]) -> list[Tag]:
-    tags = add_tag(tags, "has_dedicated_acl", "true")
-    return tags
 
 
 @pipeline_operation("Creating CloudFront distribution")
@@ -169,11 +163,11 @@ def create_distribution(operation_id: int, *, operation, db, **kwargs):
         "IsIPV6Enabled": True,
     }
 
-    tags = service_instance.tags if service_instance.tags else []
-
     if is_cdn_with_dedicated_waf_instance(service_instance):
         distribution_config["WebACLId"] = service_instance.dedicated_waf_web_acl_arn
-        tags = update_cdn_with_dedicated_waf_instance_tags(tags)
+        service_instance.add_dedicated_web_acl_tag()
+
+    tags = service_instance.tags if service_instance.tags else []
 
     distribution_config_with_tags = {
         "DistributionConfig": distribution_config,
@@ -341,14 +335,14 @@ def update_distribution(operation_id: str, *, operation, db, **kwargs):
     config["Aliases"] = get_aliases(service_instance)
     config["CustomErrorResponses"] = get_custom_error_responses(service_instance)
 
-    tags = service_instance.tags if service_instance.tags else []
-
     if (
         isinstance(service_instance, CDNDedicatedWAFServiceInstance)
         and service_instance.dedicated_waf_web_acl_arn
     ):
         config["WebACLId"] = service_instance.dedicated_waf_web_acl_arn
-        tags = update_cdn_with_dedicated_waf_instance_tags(tags)
+        service_instance.add_dedicated_web_acl_tag()
+
+    tags = service_instance.tags if service_instance.tags else []
 
     cloudfront.update_distribution(
         DistributionConfig=config,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,7 @@ from tests.lib.identifiers import (
     current_cert_id,
     cloudfront_distribution_arn,
     protection_id,
+    dedicated_waf_web_acl_arn,
 )  # noqa 41
 
 

--- a/tests/integration/cdn/test_cdn_updates.py
+++ b/tests/integration/cdn/test_cdn_updates.py
@@ -18,6 +18,7 @@ def cdn_instance_ready_for_update(clean_db):
         domain_internal="fake1234.cloudfront.net",
         route53_alias_hosted_zone="Z2FDTNDATAQYW2",
         cloudfront_distribution_id="FakeDistributionId",
+        cloudfront_distribution_arn="fake-arn",
         cloudfront_origin_hostname="newer-origin.com",
         cloudfront_origin_path="/somewhere-else",
         origin_protocol_policy="https-only",
@@ -99,6 +100,9 @@ def test_update_with_new_style_response(
         cache_policy_id="my-cache-policy",
         origin_request_policy_id="my-origin-policy",
     )
+
+    tags = service_instance.tags or []
+    cloudfront.expect_tag_resource(service_instance.cloudfront_distribution_arn, tags)
 
     cloudfront_tasks.update_distribution.call_local("1")
     clean_db.session.expunge_all()

--- a/tests/integration/tasks/test_cloudfront.py
+++ b/tests/integration/tasks/test_cloudfront.py
@@ -1,6 +1,10 @@
 import pytest
 
-from broker.tasks.cloudfront import wait_for_distribution_disabled, update_distribution
+from broker.tasks.cloudfront import (
+    wait_for_distribution_disabled,
+    create_distribution,
+    update_distribution,
+)
 from broker.models import Operation, ServiceInstanceTypes
 from broker.extensions import config
 
@@ -156,6 +160,58 @@ def test_cloudfront_wait_distribution_disabled_error_max_retries(
 
     # asserts that all the mocked calls above were made
     cloudfront.assert_no_pending_responses()
+
+
+@pytest.mark.parametrize(
+    "instance_factory",
+    [
+        factories.CDNServiceInstanceFactory,
+        factories.CDNDedicatedWAFServiceInstanceFactory,
+    ],
+)
+def test_cloudfront_create_distribution(
+    clean_db,
+    service_instance,
+    operation_id,
+    cloudfront,
+):
+    cloudfront.expect_get_distribution_returning_no_such_distribution(
+        distribution_id=service_instance.cloudfront_distribution_id,
+    )
+
+    if service_instance.instance_type == ServiceInstanceTypes.CDN.value:
+        cloudfront.expect_create_distribution_with_tags(
+            caller_reference=service_instance.id,
+            domains=service_instance.domain_names,
+            certificate_id=service_instance.new_certificate.iam_server_certificate_id,
+            origin_hostname=service_instance.cloudfront_origin_hostname,
+            origin_path=service_instance.cloudfront_origin_path,
+            distribution_id=service_instance.cloudfront_distribution_id,
+            distribution_hostname=service_instance.cloudfront_origin_hostname,
+            bucket_prefix=f"{service_instance.id}/",
+        )
+    elif service_instance.instance_type == ServiceInstanceTypes.CDN_DEDICATED_WAF.value:
+        cloudfront.expect_create_distribution_with_tags(
+            caller_reference=service_instance.id,
+            domains=service_instance.domain_names,
+            certificate_id=service_instance.new_certificate.iam_server_certificate_id,
+            origin_hostname=service_instance.cloudfront_origin_hostname,
+            origin_path=service_instance.cloudfront_origin_path,
+            distribution_id=service_instance.cloudfront_distribution_id,
+            distribution_hostname=service_instance.cloudfront_origin_hostname,
+            bucket_prefix=f"{service_instance.id}/",
+            dedicated_waf_web_acl_arn=service_instance.dedicated_waf_web_acl_arn,
+        )
+
+    create_distribution.call_local(operation_id)
+
+    # asserts that all the mocked calls above were made
+    cloudfront.assert_no_pending_responses()
+
+    clean_db.session.expunge_all()
+
+    operation = clean_db.session.get(Operation, operation_id)
+    assert operation.step_description == "Creating CloudFront distribution"
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/tasks/test_cloudfront.py
+++ b/tests/integration/tasks/test_cloudfront.py
@@ -1,9 +1,7 @@
 import pytest
 
-from broker.tasks.cloudfront import (
-    wait_for_distribution_disabled,
-)
-from broker.models import Operation
+from broker.tasks.cloudfront import wait_for_distribution_disabled, update_distribution
+from broker.models import Operation, ServiceInstanceTypes
 from broker.extensions import config
 
 from tests.lib import factories
@@ -15,20 +13,36 @@ def service_instance(
     operation_id,
     service_instance_id,
     cloudfront_distribution_arn,
+    dedicated_waf_web_acl_arn,
     instance_factory,
 ):
-    service_instance = instance_factory.create(
-        id=service_instance_id,
-        domain_names=["example.com", "foo.com"],
-        domain_internal="fake1234.cloudfront.net",
-        route53_alias_hosted_zone="Z2FDTNDATAQYW2",
-        cloudfront_distribution_id="FakeDistributionId",
-        cloudfront_distribution_arn=cloudfront_distribution_arn,
-        cloudfront_origin_hostname="origin_hostname",
-        cloudfront_origin_path="origin_path",
-        origin_protocol_policy="https-only",
-        forwarded_headers=["HOST"],
-    )
+    if instance_factory == factories.CDNServiceInstanceFactory:
+        service_instance = instance_factory.create(
+            id=service_instance_id,
+            domain_names=["example.com", "foo.com"],
+            domain_internal="fake1234.cloudfront.net",
+            route53_alias_hosted_zone="Z2FDTNDATAQYW2",
+            cloudfront_distribution_id="FakeDistributionId",
+            cloudfront_distribution_arn=cloudfront_distribution_arn,
+            cloudfront_origin_hostname="origin_hostname",
+            cloudfront_origin_path="origin_path",
+            origin_protocol_policy="https-only",
+            forwarded_headers=["HOST"],
+        )
+    elif instance_factory == factories.CDNDedicatedWAFServiceInstanceFactory:
+        service_instance = instance_factory.create(
+            id=service_instance_id,
+            domain_names=["example.com", "foo.com"],
+            domain_internal="fake1234.cloudfront.net",
+            route53_alias_hosted_zone="Z2FDTNDATAQYW2",
+            cloudfront_distribution_id="FakeDistributionId",
+            cloudfront_distribution_arn=cloudfront_distribution_arn,
+            cloudfront_origin_hostname="origin_hostname",
+            cloudfront_origin_path="origin_path",
+            origin_protocol_policy="https-only",
+            forwarded_headers=["HOST"],
+            dedicated_waf_web_acl_arn=dedicated_waf_web_acl_arn,
+        )
     new_cert = factories.CertificateFactory.create(
         service_instance=service_instance,
         private_key_pem="SOMEPRIVATEKEY",
@@ -142,3 +156,62 @@ def test_cloudfront_wait_distribution_disabled_error_max_retries(
 
     # asserts that all the mocked calls above were made
     cloudfront.assert_no_pending_responses()
+
+
+@pytest.mark.parametrize(
+    "instance_factory",
+    [
+        factories.CDNServiceInstanceFactory,
+        factories.CDNDedicatedWAFServiceInstanceFactory,
+    ],
+)
+def test_cloudfront_update_distribution(
+    clean_db,
+    service_instance,
+    operation_id,
+    cloudfront,
+):
+    cloudfront.expect_get_distribution_config(
+        caller_reference="asdf",
+        domains=service_instance.domain_names,
+        certificate_id=service_instance.new_certificate.iam_server_certificate_id,
+        origin_hostname=service_instance.cloudfront_origin_hostname,
+        origin_path=service_instance.cloudfront_origin_path,
+        distribution_id=service_instance.cloudfront_distribution_id,
+    )
+
+    if service_instance.instance_type == ServiceInstanceTypes.CDN.value:
+        cloudfront.expect_update_distribution(
+            caller_reference="asdf",
+            domains=service_instance.domain_names,
+            certificate_id=service_instance.new_certificate.iam_server_certificate_id,
+            origin_hostname=service_instance.cloudfront_origin_hostname,
+            origin_path=service_instance.cloudfront_origin_path,
+            distribution_id=service_instance.cloudfront_distribution_id,
+            distribution_hostname=service_instance.cloudfront_origin_hostname,
+        )
+        tags = []
+    if service_instance.instance_type == ServiceInstanceTypes.CDN_DEDICATED_WAF.value:
+        cloudfront.expect_update_distribution(
+            caller_reference="asdf",
+            domains=service_instance.domain_names,
+            certificate_id=service_instance.new_certificate.iam_server_certificate_id,
+            origin_hostname=service_instance.cloudfront_origin_hostname,
+            origin_path=service_instance.cloudfront_origin_path,
+            distribution_id=service_instance.cloudfront_distribution_id,
+            distribution_hostname=service_instance.cloudfront_origin_hostname,
+            dedicated_waf_web_acl_arn=service_instance.dedicated_waf_web_acl_arn,
+        )
+        tags = [{"Key": "has_dedicated_acl", "Value": "true"}]
+
+    cloudfront.expect_tag_resource(service_instance.cloudfront_distribution_arn, tags)
+
+    update_distribution.call_local(operation_id)
+
+    # asserts that all the mocked calls above were made
+    cloudfront.assert_no_pending_responses()
+
+    clean_db.session.expunge_all()
+
+    operation = clean_db.session.get(Operation, operation_id)
+    assert operation.step_description == "Updating CloudFront distribution"

--- a/tests/lib/cdn/update.py
+++ b/tests/lib/cdn/update.py
@@ -3,8 +3,8 @@ from datetime import date
 import pytest  # noqa F401
 
 from broker.extensions import config, db
+from broker.lib.tags import add_tag
 from broker.models import Operation, CDNServiceInstance, CDNDedicatedWAFServiceInstance
-from broker.tasks.cloudfront import update_cdn_with_dedicated_waf_instance_tags
 
 from tests.lib.client import check_last_operation_description
 from tests.lib.update import (
@@ -161,11 +161,12 @@ def subtest_updates_cloudfront(
         dedicated_waf_web_acl_arn=dedicated_waf_web_acl_arn,
     )
 
-    tags = service_instance.tags
     if instance_model == CDNDedicatedWAFServiceInstance:
-        tags = update_cdn_with_dedicated_waf_instance_tags(service_instance.tags)
+        service_instance.add_dedicated_web_acl_tag()
 
-    cloudfront.expect_tag_resource(service_instance.cloudfront_distribution_arn, tags)
+    cloudfront.expect_tag_resource(
+        service_instance.cloudfront_distribution_arn, service_instance.tags
+    )
 
     tasks.run_queued_tasks_and_enqueue_dependents()
     db.session.expunge_all()
@@ -409,9 +410,11 @@ def subtest_update_same_domains_updates_cloudfront(
 
     tags = service_instance.tags
     if instance_model == CDNDedicatedWAFServiceInstance:
-        tags = update_cdn_with_dedicated_waf_instance_tags(service_instance.tags)
+        service_instance.add_dedicated_web_acl_tag()
 
-    cloudfront.expect_tag_resource(service_instance.cloudfront_distribution_arn, tags)
+    cloudfront.expect_tag_resource(
+        service_instance.cloudfront_distribution_arn, service_instance.tags
+    )
 
     tasks.run_queued_tasks_and_enqueue_dependents()
     db.session.expunge_all()

--- a/tests/lib/fake_cloudfront.py
+++ b/tests/lib/fake_cloudfront.py
@@ -5,7 +5,6 @@ import pytest
 
 from broker.aws import cloudfront as real_cloudfront
 from broker.lib.tags import add_tag, Tag
-from broker.tasks.cloudfront import update_cdn_with_dedicated_waf_instance_tags
 from tests.lib.fake_aws import FakeAWS
 
 
@@ -337,6 +336,7 @@ class FakeCloudFront(FakeAWS):
         )
 
     def expect_tag_resource(self, cloudfront_distribution_arn: str, tags: list[Tag]):
+        tags = tags if tags else []
         self.stubber.add_response(
             "tag_resource",
             {},
@@ -721,7 +721,7 @@ class FakeCloudFront(FakeAWS):
 
         if dedicated_waf_web_acl_arn:
             distribution_config["WebACLId"] = dedicated_waf_web_acl_arn
-            tags = update_cdn_with_dedicated_waf_instance_tags(tags)
+            tags = add_tag(tags, {"Key": "has_dedicated_acl", "Value": "true"})
 
         distribution_config_with_tags = {
             "DistributionConfig": distribution_config,

--- a/tests/lib/fake_cloudfront.py
+++ b/tests/lib/fake_cloudfront.py
@@ -5,6 +5,7 @@ import pytest
 
 from broker.aws import cloudfront as real_cloudfront
 from broker.lib.tags import add_tag, Tag
+from broker.tasks.cloudfront import update_cdn_with_dedicated_waf_instance_tags
 from tests.lib.fake_aws import FakeAWS
 
 
@@ -720,7 +721,7 @@ class FakeCloudFront(FakeAWS):
 
         if dedicated_waf_web_acl_arn:
             distribution_config["WebACLId"] = dedicated_waf_web_acl_arn
-            tags = add_tag(tags, "has_dedicated_acl", "true")
+            tags = update_cdn_with_dedicated_waf_instance_tags(tags)
 
         distribution_config_with_tags = {
             "DistributionConfig": distribution_config,

--- a/tests/lib/identifiers.py
+++ b/tests/lib/identifiers.py
@@ -34,6 +34,11 @@ def protection_id():
     return str(uuid.uuid4())
 
 
+@pytest.fixture
+def dedicated_waf_web_acl_arn():
+    return str(uuid.uuid4())
+
+
 def get_server_certificate_name(instance_id, certificate_id):
     today = date.today().isoformat()
     return f"{instance_id}-{today}-{certificate_id}"

--- a/tests/unit/test_tags.py
+++ b/tests/unit/test_tags.py
@@ -56,14 +56,14 @@ def catalog(plan):
 
 
 def test_add_tag():
-    tags = add_tag([], "foo", "bar")
+    tags = add_tag([], {"Key": "foo", "Value": "bar"})
     assert tags == [{"Key": "foo", "Value": "bar"}]
 
 
 def test_add_tag_errors_on_existing_tag():
     tags = [{"Key": "foo", "Value": "bar"}]
     with pytest.raises(RuntimeError):
-        add_tag(tags, "foo", "bar")
+        add_tag(tags, {"Key": "foo", "Value": "bar"})
 
 
 def test_generate_instance_tags(


### PR DESCRIPTION
## Changes proposed in this pull request:

The `update_distribution` logic was not updating CDN with dedicated WAF instances with the correct tags nor applying the dedicated WAF web ACL to the CDN itself. This PR fixes both of those issues and adds the relevant tests for the updated behaviors.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

The changes in the PR themselves have no security impact as they are just bug fixes and do not expose anything sensitive. For users of CDN with dedicated WAF services though, the security benefit of these changes is actually getting a dedicated WAF for your CDN.
