### PR TITLE
Fix unit tests

### DIFF
--- a/tests/integration/api/test_cdn_provision_common_checks.py
+++ b/tests/integration/api/test_cdn_provision_common_checks.py
@@ -13,11 +13,6 @@ def provision_params():
     return {"domains": "example.com", "alarm_notification_email": "foo@bar.com"}
 
 
-@pytest.fixture(scope="module")
-def cache_policy_id():
-    return str(uuid.uuid4())
-
-
 @pytest.mark.parametrize(
     "instance_model",
     [CDNServiceInstance, CDNDedicatedWAFServiceInstance],

--- a/tests/lib/identifiers.py
+++ b/tests/lib/identifiers.py
@@ -44,6 +44,6 @@ def get_server_certificate_name(instance_id, certificate_id):
     return f"{instance_id}-{today}-{certificate_id}"
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def cache_policy_id():
     return str(uuid.uuid4())


### PR DESCRIPTION
## Changes proposed in this pull request:

- [assign session scope to cache_policy_id fixture so that the same value is used across all the tests(https://github.com/cloud-gov/external-domain-broker/commit/629c9bd8f62fdea6fe84276e941e8ef19cd873c1) 
- [remove duplicate fixture](https://github.com/cloud-gov/external-domain-broker/commit/2a4389a5ad3ea250d76329b23d035bd290d413c9)

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None. The code and changes are not sensitive
