### PR TITLE
Fix policy handling

### DIFF
--- a/broker/config.py
+++ b/broker/config.py
@@ -62,10 +62,10 @@ class Config:
         self.REQUEST_TIMEOUT = 30
 
         # see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html
-        # NOTE: The values in the list are not the same as the policy names on the AWS documentation. These values
-        # are the actual policy names as returned by a CloudFront ListCachePolicies request. Since our code will
-        # check for allowed policies against the list of names returned by the API, we use the names from the API
-        # response instead of the documentation.
+        # NOTE: The values in the list are not the same as the policy names on the AWS documentation page. These
+        # values are the actual policy names as returned by a CloudFront ListCachePolicies request. Since our code
+        # will check for allowed policies against the list of names returned by the API, we use the names from the
+        # API response instead of the documentation.
         self.ALLOWED_AWS_MANAGED_CACHE_POLICIES = [
             "Managed-CachingDisabled",
             "Managed-CachingOptimized",
@@ -75,9 +75,13 @@ class Config:
         ]
 
         # see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-origin-request-policies.html
+        # NOTE: The values in the list are not the same as the policy names on the AWS documentation page. These
+        # values are the actual policy names as returned by a CloudFront ListOriginRequestPolicies request. Since
+        # our code will check for allowed policies against the list of names returned by the API, we use the names
+        # from the API response instead of the documentation.
         self.ALLOWED_AWS_MANAGED_ORIGIN_VIEWER_REQUEST_POLICIES = [
-            "AllViewer",
-            "AllViewerAndCloudFrontHeaders-2022-06",
+            "Managed-AllViewer",
+            "Managed-AllViewerAndCloudFrontHeaders-2022-06",
         ]
 
 

--- a/broker/config.py
+++ b/broker/config.py
@@ -62,10 +62,14 @@ class Config:
         self.REQUEST_TIMEOUT = 30
 
         # see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html
+        # NOTE: The values in the list are not the same as the policy names on the AWS documentation. These values
+        # are the actual policy names as returned by a CloudFront ListCachePolicies request. Since our code will
+        # check for allowed policies against the list of names returned by the API, we use the names from the API
+        # response instead of the documentation.
         self.ALLOWED_AWS_MANAGED_CACHE_POLICIES = [
-            "CachingDisabled",
-            "CachingOptimized",
-            "CachingOptimizedForUncompressedObjects",
+            "Managed-CachingDisabled",
+            "Managed-CachingOptimized",
+            "Managed-CachingOptimizedForUncompressedObjects",
             "UseOriginCacheControlHeaders",
             "UseOriginCacheControlHeaders-QueryStrings",
         ]

--- a/broker/lib/cache_policy_manager.py
+++ b/broker/lib/cache_policy_manager.py
@@ -1,6 +1,10 @@
 from broker.extensions import config
 
 
+def is_cache_policy_supported(aws_policy_name, allowed_aws_policy_names):
+    return aws_policy_name in allowed_aws_policy_names
+
+
 class CachePolicyManager:
     def __init__(self, cloudfront):
         self._managed_policies = None
@@ -33,7 +37,9 @@ class CachePolicyManager:
 
             policy = item["CachePolicy"]
             policy_name = policy["CachePolicyConfig"]["Name"]
-            if policy_name not in config.ALLOWED_AWS_MANAGED_CACHE_POLICIES:
+            if not is_cache_policy_supported(
+                policy_name, config.ALLOWED_AWS_MANAGED_CACHE_POLICIES
+            ):
                 continue
 
             cache_policies_map[policy_name] = policy["Id"]

--- a/broker/lib/cache_policy_manager.py
+++ b/broker/lib/cache_policy_manager.py
@@ -1,7 +1,7 @@
 from broker.extensions import config
 
 
-def is_cache_policy_supported(aws_policy_name, allowed_aws_policy_names):
+def is_cache_policy_allowed(aws_policy_name, allowed_aws_policy_names):
     return aws_policy_name in allowed_aws_policy_names
 
 
@@ -37,7 +37,7 @@ class CachePolicyManager:
 
             policy = item["CachePolicy"]
             policy_name = policy["CachePolicyConfig"]["Name"]
-            if not is_cache_policy_supported(
+            if not is_cache_policy_allowed(
                 policy_name, config.ALLOWED_AWS_MANAGED_CACHE_POLICIES
             ):
                 continue

--- a/broker/lib/cdn.py
+++ b/broker/lib/cdn.py
@@ -7,7 +7,10 @@ from broker.extensions import config
 
 from broker.lib.cache_policy_manager import CachePolicyManager, is_cache_policy_allowed
 from broker.lib.client_error import ClientError
-from broker.lib.origin_request_policy_manager import OriginRequestPolicyManager
+from broker.lib.origin_request_policy_manager import (
+    is_origin_request_policy_allowed,
+    OriginRequestPolicyManager,
+)
 from broker.lib.utils import (
     parse_cookie_options,
     parse_header_options,
@@ -60,9 +63,8 @@ def parse_origin_request_policy(
     origin_request_policy = params.get("origin_request_policy", None)
     if not origin_request_policy:
         return None
-    if (
-        origin_request_policy
-        not in config.ALLOWED_AWS_MANAGED_ORIGIN_VIEWER_REQUEST_POLICIES
+    if not is_origin_request_policy_allowed(
+        origin_request_policy, config.ALLOWED_AWS_MANAGED_ORIGIN_VIEWER_REQUEST_POLICIES
     ):
         raise errors.ErrBadRequest(
             f"'{origin_request_policy}' is not an allowed value for origin_request_policy."

--- a/broker/lib/cdn.py
+++ b/broker/lib/cdn.py
@@ -5,7 +5,7 @@ from broker import validators
 from broker.aws import cloudfront
 from broker.extensions import config
 
-from broker.lib.cache_policy_manager import CachePolicyManager
+from broker.lib.cache_policy_manager import CachePolicyManager, is_cache_policy_allowed
 from broker.lib.client_error import ClientError
 from broker.lib.origin_request_policy_manager import OriginRequestPolicyManager
 from broker.lib.utils import (
@@ -45,7 +45,9 @@ def parse_cache_policy(params, cache_policy_manager: CachePolicyManager) -> str:
     cache_policy = params.get("cache_policy", None)
     if not cache_policy:
         return None
-    if cache_policy not in config.ALLOWED_AWS_MANAGED_CACHE_POLICIES:
+    if not is_cache_policy_allowed(
+        cache_policy, config.ALLOWED_AWS_MANAGED_CACHE_POLICIES
+    ):
         raise errors.ErrBadRequest(
             f"'{cache_policy}' is not an allowed value for cache_policy."
         )

--- a/broker/lib/origin_request_policy_manager.py
+++ b/broker/lib/origin_request_policy_manager.py
@@ -1,6 +1,10 @@
 from broker.extensions import config
 
 
+def is_origin_request_policy_allowed(aws_policy_name, allowed_aws_policy_names):
+    return aws_policy_name in allowed_aws_policy_names
+
+
 class OriginRequestPolicyManager:
     def __init__(self, cloudfront):
         self._managed_policies = None
@@ -38,9 +42,8 @@ class OriginRequestPolicyManager:
 
             policy = item["OriginRequestPolicy"]
             policy_name = policy["OriginRequestPolicyConfig"]["Name"]
-            if (
-                policy_name
-                not in config.ALLOWED_AWS_MANAGED_ORIGIN_VIEWER_REQUEST_POLICIES
+            if not is_origin_request_policy_allowed(
+                policy_name, config.ALLOWED_AWS_MANAGED_ORIGIN_VIEWER_REQUEST_POLICIES
             ):
                 continue
 

--- a/tests/integration/api/test_cdn_provision_common_checks.py
+++ b/tests/integration/api/test_cdn_provision_common_checks.py
@@ -443,11 +443,11 @@ def test_provision_sets_cache_policy(
 ):
     provision_params.update(
         {
-            "cache_policy": "CachingDisabled",
+            "cache_policy": "Managed-CachingDisabled",
         }
     )
     dns.add_cname("_acme-challenge.example.com")
-    cache_policies = [{"id": cache_policy_id, "name": "CachingDisabled"}]
+    cache_policies = [{"id": cache_policy_id, "name": "Managed-CachingDisabled"}]
 
     # cache_policy_manager is managed in global state, so that in real API usage
     # it caches the cache policies fetched by AWS. For testing purposes, we mock

--- a/tests/integration/api/test_cdn_provision_common_checks.py
+++ b/tests/integration/api/test_cdn_provision_common_checks.py
@@ -532,11 +532,13 @@ def test_provision_sets_origin_request_policy(
 ):
     provision_params.update(
         {
-            "origin_request_policy": "AllViewer",
+            "origin_request_policy": "Managed-AllViewer",
         }
     )
     dns.add_cname("_acme-challenge.example.com")
-    origin_request_policies = [{"id": origin_request_policy_id, "name": "AllViewer"}]
+    origin_request_policies = [
+        {"id": origin_request_policy_id, "name": "Managed-AllViewer"}
+    ]
 
     # origin_request_policy_manager is managed in global state, so that in real API usage
     # it caches the origin request policies fetched by AWS. For testing purposes, we mock

--- a/tests/integration/api/test_cdn_update_common_checks.py
+++ b/tests/integration/api/test_cdn_update_common_checks.py
@@ -389,7 +389,7 @@ def test_update_sets_cache_policy_id(
     mocked_cf_api,
 ):
     dns.add_cname("_acme-challenge.example.com")
-    cache_policies = [{"id": cache_policy_id, "name": "CachingDisabled"}]
+    cache_policies = [{"id": cache_policy_id, "name": "Managed-CachingDisabled"}]
 
     # cache_policy_manager is managed in global state, so that in real API usage
     # it caches the cache policies fetched by AWS. For testing purposes, we mock
@@ -403,7 +403,7 @@ def test_update_sets_cache_policy_id(
             service_instance.id,
             params={
                 "domains": ["example.com"],
-                "cache_policy": "CachingDisabled",
+                "cache_policy": "Managed-CachingDisabled",
                 "alarm_notification_email": "foo@bar",
             },
         )

--- a/tests/integration/api/test_cdn_update_common_checks.py
+++ b/tests/integration/api/test_cdn_update_common_checks.py
@@ -460,7 +460,9 @@ def test_update_sets_origin_request_policy_id(
     mocked_cf_api,
 ):
     dns.add_cname("_acme-challenge.example.com")
-    origin_request_policies = [{"id": origin_request_policy_id, "name": "AllViewer"}]
+    origin_request_policies = [
+        {"id": origin_request_policy_id, "name": "Managed-AllViewer"}
+    ]
 
     # origin_request_policy_manager is managed in global state, so that in real API usage
     # it caches the origin request policies fetched by AWS. For testing purposes, we mock
@@ -480,7 +482,7 @@ def test_update_sets_origin_request_policy_id(
             service_instance.id,
             params={
                 "domains": ["example.com"],
-                "origin_request_policy": "AllViewer",
+                "origin_request_policy": "Managed-AllViewer",
                 "alarm_notification_email": "foo@bar",
             },
         )

--- a/tests/integration/tasks/test_cloudfront.py
+++ b/tests/integration/tasks/test_cloudfront.py
@@ -402,7 +402,7 @@ def test_cloudfront_update_distribution_sets_cache_policy(
         origin_hostname=service_instance.cloudfront_origin_hostname,
         origin_path=service_instance.cloudfront_origin_path,
         distribution_id=service_instance.cloudfront_distribution_id,
-        compress=True,  # ensure that any pre-existing settings get preserved on update
+        compress=True,  # ensure that pre-existing DefaultCacheBehavior["Compress"] value gets preserved on update
     )
 
     service_instance.cache_policy_id = cache_policy_id

--- a/tests/integration/tasks/test_cloudfront.py
+++ b/tests/integration/tasks/test_cloudfront.py
@@ -402,6 +402,7 @@ def test_cloudfront_update_distribution_sets_cache_policy(
         origin_hostname=service_instance.cloudfront_origin_hostname,
         origin_path=service_instance.cloudfront_origin_path,
         distribution_id=service_instance.cloudfront_distribution_id,
+        compress=True,  # ensure that any pre-existing settings get preserved on update
     )
 
     service_instance.cache_policy_id = cache_policy_id
@@ -418,6 +419,7 @@ def test_cloudfront_update_distribution_sets_cache_policy(
             distribution_id=service_instance.cloudfront_distribution_id,
             distribution_hostname=service_instance.cloudfront_origin_hostname,
             cache_policy_id=cache_policy_id,
+            compress=True,
         )
     if service_instance.instance_type == ServiceInstanceTypes.CDN_DEDICATED_WAF.value:
         cloudfront.expect_update_distribution(
@@ -430,6 +432,7 @@ def test_cloudfront_update_distribution_sets_cache_policy(
             distribution_hostname=service_instance.cloudfront_origin_hostname,
             dedicated_waf_web_acl_arn=service_instance.dedicated_waf_web_acl_arn,
             cache_policy_id=cache_policy_id,
+            compress=True,
         )
 
     cloudfront.expect_tag_resource(service_instance)

--- a/tests/lib/fake_cloudfront.py
+++ b/tests/lib/fake_cloudfront.py
@@ -84,6 +84,7 @@ class FakeCloudFront(FakeAWS):
         custom_error_responses: str = None,
         include_le_bucket: bool = False,
         include_log_bucket: bool = True,
+        compress: bool = None,
     ):
         if custom_error_responses is None:
             custom_error_responses = {"Quantity": 0}
@@ -107,6 +108,7 @@ class FakeCloudFront(FakeAWS):
                     custom_error_responses=custom_error_responses,
                     include_le_bucket=include_le_bucket,
                     include_log_bucket=include_log_bucket,
+                    compress=compress,
                 ),
                 "ETag": self.etag,
             },
@@ -296,6 +298,7 @@ class FakeCloudFront(FakeAWS):
         dedicated_waf_web_acl_arn: str = None,
         cache_policy_id: str = None,
         origin_request_policy_id: str = None,
+        compress: bool = None,
     ):
         self.stubber.add_response(
             "update_distribution",
@@ -330,6 +333,7 @@ class FakeCloudFront(FakeAWS):
                     dedicated_waf_web_acl_arn=dedicated_waf_web_acl_arn,
                     cache_policy_id=cache_policy_id,
                     origin_request_policy_id=origin_request_policy_id,
+                    compress=compress,
                 ),
                 "Id": distribution_id,
                 "IfMatch": self.etag,
@@ -448,6 +452,7 @@ class FakeCloudFront(FakeAWS):
         cache_policy_id: str = None,
         origin_request_policy_id: str = None,
         dedicated_waf_web_acl_arn: str = None,
+        compress: bool = None,
     ) -> Dict[str, Any]:
         if forwarded_headers is None:
             forwarded_headers = ["HOST"]
@@ -482,6 +487,10 @@ class FakeCloudFront(FakeAWS):
             "DefaultTTL": 86400,
             "MaxTTL": 31536000,
         }
+
+        if compress:
+            default_cache_behavior.update({"Compress": True})
+
         if cache_policy_id is None:
             default_cache_behavior.update(
                 {

--- a/tests/unit/test_cache_policy_manager.py
+++ b/tests/unit/test_cache_policy_manager.py
@@ -5,47 +5,47 @@ from broker.lib.cache_policy_manager import CachePolicyManager
 
 
 def test_managed_cache_policies(cloudfront, cache_policy_id):
-    policies = [{"id": cache_policy_id, "name": "CachingDisabled"}]
+    policies = [{"id": cache_policy_id, "name": "Managed-CachingDisabled"}]
 
     cache_policy_manager = CachePolicyManager(cloudfront_svc)
     cloudfront.expect_list_cache_policies("managed", policies)
     assert cache_policy_manager.managed_policies == {
-        "CachingDisabled": cache_policy_id,
+        "Managed-CachingDisabled": cache_policy_id,
     }
 
 
 def test_managed_cache_policies_handles_paging(cloudfront, cache_policy_id):
-    policies = [{"id": cache_policy_id, "name": "CachingDisabled"}]
+    policies = [{"id": cache_policy_id, "name": "Managed-CachingDisabled"}]
     cloudfront.expect_list_cache_policies("managed", policies, next_marker="next")
 
     policy2_id = str(uuid.uuid4())
-    policies = [{"id": policy2_id, "name": "CachingOptimized"}]
+    policies = [{"id": policy2_id, "name": "Managed-CachingOptimized"}]
 
     cloudfront.expect_list_cache_policies("managed", policies, marker="next")
 
     cache_policy_manager = CachePolicyManager(cloudfront_svc)
 
     assert cache_policy_manager.managed_policies == {
-        "CachingDisabled": cache_policy_id,
-        "CachingOptimized": policy2_id,
+        "Managed-CachingDisabled": cache_policy_id,
+        "Managed-CachingOptimized": policy2_id,
     }
 
 
 def test_managed_cache_policies_ignores_unknown_policies(cloudfront, cache_policy_id):
     policies = [
-        {"id": cache_policy_id, "name": "CachingDisabled"},
+        {"id": cache_policy_id, "name": "Managed-CachingDisabled"},
         {"id": "id-1", "name": "FoobarPolicy"},
     ]
 
     cache_policy_manager = CachePolicyManager(cloudfront_svc)
     cloudfront.expect_list_cache_policies("managed", policies)
     assert cache_policy_manager.managed_policies == {
-        "CachingDisabled": cache_policy_id,
+        "Managed-CachingDisabled": cache_policy_id,
     }
 
 
 def test_managed_cache_policies_returns_saved_results(cloudfront, cache_policy_id):
-    policies = [{"id": cache_policy_id, "name": "CachingDisabled"}]
+    policies = [{"id": cache_policy_id, "name": "Managed-CachingDisabled"}]
 
     cache_policy_manager = CachePolicyManager(cloudfront_svc)
     cloudfront.expect_list_cache_policies("managed", policies)
@@ -53,15 +53,16 @@ def test_managed_cache_policies_returns_saved_results(cloudfront, cache_policy_i
     # second call should not cause an API request
     policies = cache_policy_manager.managed_policies
     assert policies == {
-        "CachingDisabled": cache_policy_id,
+        "Managed-CachingDisabled": cache_policy_id,
     }
 
 
 def test_get_managed_cache_policy_id(cloudfront, cache_policy_id):
-    policies = [{"id": cache_policy_id, "name": "CachingDisabled"}]
+    policies = [{"id": cache_policy_id, "name": "Managed-CachingDisabled"}]
 
     cache_policy_manager = CachePolicyManager(cloudfront_svc)
     cloudfront.expect_list_cache_policies("managed", policies)
     assert (
-        cache_policy_manager.get_managed_policy_id("CachingDisabled") == cache_policy_id
+        cache_policy_manager.get_managed_policy_id("Managed-CachingDisabled")
+        == cache_policy_id
     )

--- a/tests/unit/test_cache_policy_manager.py
+++ b/tests/unit/test_cache_policy_manager.py
@@ -1,7 +1,12 @@
 import uuid
 
 from broker.aws import cloudfront as cloudfront_svc
-from broker.lib.cache_policy_manager import CachePolicyManager
+from broker.lib.cache_policy_manager import CachePolicyManager, is_cache_policy_allowed
+
+
+def test_is_cache_policy_allowed():
+    assert is_cache_policy_allowed("Policy1", ["Policy1"]) == True
+    assert is_cache_policy_allowed("Policy1", ["Policy2"]) == False
 
 
 def test_managed_cache_policies(cloudfront, cache_policy_id):

--- a/tests/unit/test_cdn.py
+++ b/tests/unit/test_cdn.py
@@ -25,11 +25,13 @@ def test_parse_cache_policy_returns_none(cache_policy_manager):
 def test_parse_cache_policy_returns_valid_cache_policy(
     cache_policy_manager, cache_policy_id, cloudfront
 ):
-    policies = [{"id": cache_policy_id, "name": "CachingDisabled"}]
+    policies = [{"id": cache_policy_id, "name": "Managed-CachingDisabled"}]
     cloudfront.expect_list_cache_policies("managed", policies)
 
     assert (
-        parse_cache_policy({"cache_policy": "CachingDisabled"}, cache_policy_manager)
+        parse_cache_policy(
+            {"cache_policy": "Managed-CachingDisabled"}, cache_policy_manager
+        )
         == cache_policy_id
     )
 

--- a/tests/unit/test_cdn.py
+++ b/tests/unit/test_cdn.py
@@ -48,12 +48,13 @@ def test_parse_origin_request_policy_returns_none(origin_request_policy_manager)
 def test_parse_origin_request_policy_returns_valid_origin_request_policy(
     origin_request_policy_manager, origin_request_policy_id, cloudfront
 ):
-    policies = [{"id": origin_request_policy_id, "name": "AllViewer"}]
+    policies = [{"id": origin_request_policy_id, "name": "Managed-AllViewer"}]
     cloudfront.expect_list_origin_request_policies("managed", policies)
 
     assert (
         parse_origin_request_policy(
-            {"origin_request_policy": "AllViewer"}, origin_request_policy_manager
+            {"origin_request_policy": "Managed-AllViewer"},
+            origin_request_policy_manager,
         )
         == origin_request_policy_id
     )

--- a/tests/unit/test_origin_request_policy_manager.py
+++ b/tests/unit/test_origin_request_policy_manager.py
@@ -1,7 +1,15 @@
 import uuid
 
 from broker.aws import cloudfront as cloudfront_svc
-from broker.lib.origin_request_policy_manager import OriginRequestPolicyManager
+from broker.lib.origin_request_policy_manager import (
+    is_origin_request_policy_allowed,
+    OriginRequestPolicyManager,
+)
+
+
+def test_is_origin_request_policy_allowed():
+    assert is_origin_request_policy_allowed("Policy1", ["Policy1"]) == True
+    assert is_origin_request_policy_allowed("Policy1", ["Policy2"]) == False
 
 
 def test_managed_cache_policies(cloudfront, cache_policy_id):

--- a/tests/unit/test_origin_request_policy_manager.py
+++ b/tests/unit/test_origin_request_policy_manager.py
@@ -5,49 +5,51 @@ from broker.lib.origin_request_policy_manager import OriginRequestPolicyManager
 
 
 def test_managed_cache_policies(cloudfront, cache_policy_id):
-    policies = [{"id": cache_policy_id, "name": "AllViewer"}]
+    policies = [{"id": cache_policy_id, "name": "Managed-AllViewer"}]
 
     origin_request_policy_manager = OriginRequestPolicyManager(cloudfront_svc)
     cloudfront.expect_list_origin_request_policies("managed", policies)
     assert origin_request_policy_manager.managed_policies == {
-        "AllViewer": cache_policy_id,
+        "Managed-AllViewer": cache_policy_id,
     }
 
 
 def test_managed_cache_policies_handles_paging(cloudfront, cache_policy_id):
-    policies = [{"id": cache_policy_id, "name": "AllViewer"}]
+    policies = [{"id": cache_policy_id, "name": "Managed-AllViewer"}]
     cloudfront.expect_list_origin_request_policies(
         "managed", policies, next_marker="next"
     )
 
     policy2_id = str(uuid.uuid4())
-    policies = [{"id": policy2_id, "name": "AllViewerAndCloudFrontHeaders-2022-06"}]
+    policies = [
+        {"id": policy2_id, "name": "Managed-AllViewerAndCloudFrontHeaders-2022-06"}
+    ]
 
     cloudfront.expect_list_origin_request_policies("managed", policies, marker="next")
 
     origin_request_policy_manager = OriginRequestPolicyManager(cloudfront_svc)
 
     assert origin_request_policy_manager.managed_policies == {
-        "AllViewer": cache_policy_id,
-        "AllViewerAndCloudFrontHeaders-2022-06": policy2_id,
+        "Managed-AllViewer": cache_policy_id,
+        "Managed-AllViewerAndCloudFrontHeaders-2022-06": policy2_id,
     }
 
 
 def test_managed_cache_policies_ignores_unknown_policies(cloudfront, cache_policy_id):
     policies = [
-        {"id": cache_policy_id, "name": "AllViewer"},
+        {"id": cache_policy_id, "name": "Managed-AllViewer"},
         {"id": "id-1", "name": "FoobarPolicy"},
     ]
 
     origin_request_policy_manager = OriginRequestPolicyManager(cloudfront_svc)
     cloudfront.expect_list_origin_request_policies("managed", policies)
     assert origin_request_policy_manager.managed_policies == {
-        "AllViewer": cache_policy_id,
+        "Managed-AllViewer": cache_policy_id,
     }
 
 
 def test_managed_cache_policies_returns_saved_results(cloudfront, cache_policy_id):
-    policies = [{"id": cache_policy_id, "name": "AllViewer"}]
+    policies = [{"id": cache_policy_id, "name": "Managed-AllViewer"}]
 
     origin_request_policy_manager = OriginRequestPolicyManager(cloudfront_svc)
     cloudfront.expect_list_origin_request_policies("managed", policies)
@@ -55,16 +57,16 @@ def test_managed_cache_policies_returns_saved_results(cloudfront, cache_policy_i
     # second call should not cause an API request
     policies = origin_request_policy_manager.managed_policies
     assert policies == {
-        "AllViewer": cache_policy_id,
+        "Managed-AllViewer": cache_policy_id,
     }
 
 
 def test_get_managed_cache_policy_id(cloudfront, cache_policy_id):
-    policies = [{"id": cache_policy_id, "name": "AllViewer"}]
+    policies = [{"id": cache_policy_id, "name": "Managed-AllViewer"}]
 
     origin_request_policy_manager = OriginRequestPolicyManager(cloudfront_svc)
     cloudfront.expect_list_origin_request_policies("managed", policies)
     assert (
-        origin_request_policy_manager.get_managed_policy_id("AllViewer")
+        origin_request_policy_manager.get_managed_policy_id("Managed-AllViewer")
         == cache_policy_id
     )


### PR DESCRIPTION
## Changes proposed in this pull request:

When running the acceptance tests from #420 in staging, we are seeing this error:

```
KeyError: 'CachingDisabled'
```

Further investigation revealed that for [a policy name of `CachingDisabled` as mentioned in the AWS documentation](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html), the actual policy name returned by the CloudFront ListCachePolicies API is `Managed-CachingDisabled`. Since the broker was caching the policies from in AWS in a hash keyed by the policy name in the API response, `CachingDisabled` was not found and hence the `KeyError`. 

The easiest solution is to have the broker expect as input the names of the policies as returned by the CloudFront API. I will make sure to document these values on the external-domain-broker service page on the website.

I tested and discovered that this same problem would have occurred for the origin request policy names, since their names also differ between the AWS documentation page and the API response. So I fixed the problem there again by expecting the input policy names to match the values in the API response.

Most of the changes in this PR are just about updating test fixtures and expectations to match policy names as they come back in the AWS CloudFront API responses.

- Update config for allowed cache policies and origin request policies to use policy names as returned by CloudFront API
- Update various unit tests to expect policy names as returned by the CloudFront API
- Add `is_cache_policy_allowed()` function for testing if a policy name is allowed by the broker
- Update `parse_cache_policy()` to use `is_cache_policy_allowed()` for testing if the given policy name is allowed by the broker
- Add `is_origin_request_policy_allowed()` function for testing if a policy name is allowed by the broker
- Update `parse_origin_request_policy()` to use `is_origin_request_policy_allowed()` for testing if the given policy name is allowed by the broker
- Update `test_cloudfront_update_distribution_sets_cache_policy` test to ensure that existing value for `DefaultCacheBehavior['Compress']` does not get inadvertently deleted on update

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None. These code changes are not sensitive.
