### PR TITLE
update parameters for acceptance tests

### DIFF
--- a/acceptance/run.sh
+++ b/acceptance/run.sh
@@ -160,7 +160,7 @@ tests() {
       "$SERVICE_NAME" \
       "$PLAN_NAME" \
       "$INSTANCE" \
-      -c "{\"domains\": \"$DOMAIN_0, $DOMAIN_1\", \"alarm_notification_email\": \"$ALARM_NOTIFICATION_EMAIL\", \"cache_policy\": \"CachingDisabled\", \"origin_request_policy\": \"AllViewer\", \"error_responses\": {\"404\": \"/errors/404.html\"}}"
+      -c "{\"domains\": \"$DOMAIN_0, $DOMAIN_1\", \"alarm_notification_email\": \"$ALARM_NOTIFICATION_EMAIL\", \"cache_policy\": \"Managed-CachingDisabled\", \"origin_request_policy\": \"Managed-AllViewer\", \"error_responses\": {\"404\": \"/errors/404.html\"}}"
   else
     echo "Creating the service instance"
     cf create-service \


### PR DESCRIPTION
## Changes proposed in this pull request:

Part of https://github.com/cloud-gov/external-domain-broker/issues/412

- update parameters for cache policy and origin request policy in acceptance test creating a CDN with dedicated WAF instance to match expected values for broker that were changed in #421  

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None. The code changes are no sensitive
