### PR TITLE
Fix apply cache policy logic

### DIFF
--- a/acceptance/run.sh
+++ b/acceptance/run.sh
@@ -160,7 +160,7 @@ tests() {
       "$SERVICE_NAME" \
       "$PLAN_NAME" \
       "$INSTANCE" \
-      -c "{\"domains\": \"$DOMAIN_0, $DOMAIN_1\", \"alarm_notification_email\": \"$ALARM_NOTIFICATION_EMAIL\", \"cache_policy\": \"Managed-CachingDisabled\", \"origin_request_policy\": \"Managed-AllViewer\", \"error_responses\": {\"404\": \"/errors/404.html\"}}"
+      -c "{\"domains\": \"$DOMAIN_0, $DOMAIN_1\", \"alarm_notification_email\": \"$ALARM_NOTIFICATION_EMAIL\", \"cache_policy\": \"Managed-CachingOptimized\", \"origin_request_policy\": \"Managed-AllViewer\", \"error_responses\": {\"404\": \"/errors/404.html\"}}"
   else
     echo "Creating the service instance"
     cf create-service \

--- a/broker/tasks/cloudfront.py
+++ b/broker/tasks/cloudfront.py
@@ -92,13 +92,17 @@ def default_cache_behavior():
 def update_default_cache_behavior(service_instance, default_cache_behavior):
     updated_default_cache_behavior = default_cache_behavior.copy()
 
-    # ForwardedValues and CachePolicyId are mutually exclusive
-    # see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_DefaultCacheBehavior.html#cloudfront-Type-DefaultCacheBehavior-ForwardedValues
     if service_instance.cache_policy_id:
         updated_default_cache_behavior.update(
             {"CachePolicyId": service_instance.cache_policy_id}
         )
+        # see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_DefaultCacheBehavior.html#cloudfront-Type-DefaultCacheBehavior-ForwardedValues
+        # ForwardedValues and CachePolicyId are mutually exclusive
         updated_default_cache_behavior.pop("ForwardedValues", None)
+        # These fields are set by the cache policy identified by the CachePolicyId
+        updated_default_cache_behavior.pop("DefaultTTL", None)
+        updated_default_cache_behavior.pop("MinTTL", None)
+        updated_default_cache_behavior.pop("MaxTTL", None)
     else:
         updated_default_cache_behavior.update(
             {

--- a/tests/lib/fake_cloudfront.py
+++ b/tests/lib/fake_cloudfront.py
@@ -507,6 +507,9 @@ class FakeCloudFront(FakeAWS):
             )
         else:
             default_cache_behavior.update({"CachePolicyId": cache_policy_id})
+            default_cache_behavior.pop("DefaultTTL", None)
+            default_cache_behavior.pop("MinTTL", None)
+            default_cache_behavior.pop("MaxTTL", None)
 
         if origin_request_policy_id:
             default_cache_behavior.update(


### PR DESCRIPTION
## Changes proposed in this pull request:

The acceptance tests to create a CDN with dedicated WAF service instance using a managed cache policy and managed origin request policy are failing with

```
The parameter MinTTL cannot be used when a cache policy is associated to the cache behavior
```

Upon reviewing the [relevant AWS documentation](https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_DefaultCacheBehavior.html), it seems like the `MinTTL`, `MaxTTL`, and `DefaultTTL` properties are deprecated when you are supply a cache policy. 

So this PR updates the CDN provisioning logic to unset those properties when a `CachePolicyId` is supplied.

The PR also updates the acceptance test to use the `Managed-CachingOptimized` cache policy.


## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None. The code changes are not sensitive
