### PR TITLE
Fix update CDN policy logic to preserve existing values

### DIFF
--- a/broker/tasks/cloudfront.py
+++ b/broker/tasks/cloudfront.py
@@ -92,10 +92,18 @@ def default_cache_behavior():
 def update_default_cache_behavior(service_instance, default_cache_behavior):
     updated_default_cache_behavior = default_cache_behavior.copy()
 
-    if service_instance.cache_policy_id:
-        updated_default_cache_behavior.update(
-            {"CachePolicyId": service_instance.cache_policy_id}
-        )
+    # Even if properties are not set on the service instance, preserve any values
+    # from the existing DefaultCacheBehavior
+    cache_policy_id = service_instance.cache_policy_id or default_cache_behavior.get(
+        "CachePolicyId", None
+    )
+    origin_request_policy_id = (
+        service_instance.origin_request_policy_id
+        or default_cache_behavior.get("OriginRequestPolicyId", None)
+    )
+
+    if cache_policy_id:
+        updated_default_cache_behavior.update({"CachePolicyId": cache_policy_id})
         # see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_DefaultCacheBehavior.html#cloudfront-Type-DefaultCacheBehavior-ForwardedValues
         # ForwardedValues and CachePolicyId are mutually exclusive
         updated_default_cache_behavior.pop("ForwardedValues", None)
@@ -116,9 +124,9 @@ def update_default_cache_behavior(service_instance, default_cache_behavior):
         )
         updated_default_cache_behavior.pop("CachePolicyId", None)
 
-    if service_instance.origin_request_policy_id:
+    if origin_request_policy_id:
         updated_default_cache_behavior.update(
-            {"OriginRequestPolicyId": service_instance.origin_request_policy_id}
+            {"OriginRequestPolicyId": origin_request_policy_id}
         )
 
     return updated_default_cache_behavior

--- a/tests/integration/tasks/test_cloudfront.py
+++ b/tests/integration/tasks/test_cloudfront.py
@@ -542,6 +542,7 @@ def test_cloudfront_update_distribution_preserves_existing_settings(
         compress=True,
         allowed_methods=allowed_methods,
         cached_methods=cached_methods,
+        grpc_enabled=True,
     )
 
     if service_instance.instance_type == ServiceInstanceTypes.CDN.value:
@@ -558,6 +559,7 @@ def test_cloudfront_update_distribution_preserves_existing_settings(
             compress=True,
             allowed_methods=allowed_methods,
             cached_methods=cached_methods,
+            grpc_enabled=True,
         )
     if service_instance.instance_type == ServiceInstanceTypes.CDN_DEDICATED_WAF.value:
         cloudfront.expect_update_distribution(
@@ -574,6 +576,7 @@ def test_cloudfront_update_distribution_preserves_existing_settings(
             compress=True,
             allowed_methods=allowed_methods,
             cached_methods=cached_methods,
+            grpc_enabled=True,
         )
 
     cloudfront.expect_tag_resource(service_instance)

--- a/tests/integration/tasks/test_cloudfront.py
+++ b/tests/integration/tasks/test_cloudfront.py
@@ -519,7 +519,7 @@ def test_cloudfront_update_distribution_sets_origin_request_policy(
         factories.CDNDedicatedWAFServiceInstanceFactory,
     ],
 )
-def test_cloudfront_update_distribution_preserves_existing_settings(
+def test_cloudfront_update_distribution_preserves_existing_cache_settings(
     clean_db,
     service_instance,
     operation_id,
@@ -573,6 +573,78 @@ def test_cloudfront_update_distribution_preserves_existing_settings(
             dedicated_waf_web_acl_arn=service_instance.dedicated_waf_web_acl_arn,
             cache_policy_id=cache_policy_id,
             origin_request_policy_id=origin_request_policy_id,
+            compress=True,
+            allowed_methods=allowed_methods,
+            cached_methods=cached_methods,
+            grpc_enabled=True,
+        )
+
+    cloudfront.expect_tag_resource(service_instance)
+
+    update_distribution.call_local(operation_id)
+
+    # asserts that all the mocked calls above were made
+    cloudfront.assert_no_pending_responses()
+
+    clean_db.session.expunge_all()
+
+    operation = clean_db.session.get(Operation, operation_id)
+    assert operation.step_description == "Updating CloudFront distribution"
+
+
+@pytest.mark.parametrize(
+    "instance_factory",
+    [
+        factories.CDNServiceInstanceFactory,
+        factories.CDNDedicatedWAFServiceInstanceFactory,
+    ],
+)
+def test_cloudfront_update_distribution_preserves_existing_forwarded_settings(
+    clean_db,
+    service_instance,
+    operation_id,
+    cloudfront,
+):
+    allowed_methods = ["GET", "HEAD", "OPTIONS"]
+    cached_methods = ["GET", "HEAD", "OPTIONS"]
+
+    cloudfront.expect_get_distribution_config(
+        caller_reference="asdf",
+        domains=service_instance.domain_names,
+        certificate_id=service_instance.new_certificate.iam_server_certificate_id,
+        origin_hostname=service_instance.cloudfront_origin_hostname,
+        origin_path=service_instance.cloudfront_origin_path,
+        distribution_id=service_instance.cloudfront_distribution_id,
+        compress=True,
+        allowed_methods=allowed_methods,
+        cached_methods=cached_methods,
+        grpc_enabled=True,
+    )
+
+    if service_instance.instance_type == ServiceInstanceTypes.CDN.value:
+        cloudfront.expect_update_distribution(
+            caller_reference="asdf",
+            domains=service_instance.domain_names,
+            certificate_id=service_instance.new_certificate.iam_server_certificate_id,
+            origin_hostname=service_instance.cloudfront_origin_hostname,
+            origin_path=service_instance.cloudfront_origin_path,
+            distribution_id=service_instance.cloudfront_distribution_id,
+            distribution_hostname=service_instance.cloudfront_origin_hostname,
+            compress=True,
+            allowed_methods=allowed_methods,
+            cached_methods=cached_methods,
+            grpc_enabled=True,
+        )
+    if service_instance.instance_type == ServiceInstanceTypes.CDN_DEDICATED_WAF.value:
+        cloudfront.expect_update_distribution(
+            caller_reference="asdf",
+            domains=service_instance.domain_names,
+            certificate_id=service_instance.new_certificate.iam_server_certificate_id,
+            origin_hostname=service_instance.cloudfront_origin_hostname,
+            origin_path=service_instance.cloudfront_origin_path,
+            distribution_id=service_instance.cloudfront_distribution_id,
+            distribution_hostname=service_instance.cloudfront_origin_hostname,
+            dedicated_waf_web_acl_arn=service_instance.dedicated_waf_web_acl_arn,
             compress=True,
             allowed_methods=allowed_methods,
             cached_methods=cached_methods,

--- a/tests/integration/tasks/test_cloudfront.py
+++ b/tests/integration/tasks/test_cloudfront.py
@@ -515,6 +515,83 @@ def test_cloudfront_update_distribution_sets_origin_request_policy(
 @pytest.mark.parametrize(
     "instance_factory",
     [
+        factories.CDNServiceInstanceFactory,
+        factories.CDNDedicatedWAFServiceInstanceFactory,
+    ],
+)
+def test_cloudfront_update_distribution_preserves_existing_settings(
+    clean_db,
+    service_instance,
+    operation_id,
+    cloudfront,
+    cache_policy_id,
+    origin_request_policy_id,
+):
+    allowed_methods = ["GET", "HEAD", "OPTIONS"]
+    cached_methods = ["GET", "HEAD", "OPTIONS"]
+
+    cloudfront.expect_get_distribution_config(
+        caller_reference="asdf",
+        domains=service_instance.domain_names,
+        certificate_id=service_instance.new_certificate.iam_server_certificate_id,
+        origin_hostname=service_instance.cloudfront_origin_hostname,
+        origin_path=service_instance.cloudfront_origin_path,
+        distribution_id=service_instance.cloudfront_distribution_id,
+        cache_policy_id=cache_policy_id,
+        origin_request_policy_id=origin_request_policy_id,
+        compress=True,
+        allowed_methods=allowed_methods,
+        cached_methods=cached_methods,
+    )
+
+    if service_instance.instance_type == ServiceInstanceTypes.CDN.value:
+        cloudfront.expect_update_distribution(
+            caller_reference="asdf",
+            domains=service_instance.domain_names,
+            certificate_id=service_instance.new_certificate.iam_server_certificate_id,
+            origin_hostname=service_instance.cloudfront_origin_hostname,
+            origin_path=service_instance.cloudfront_origin_path,
+            distribution_id=service_instance.cloudfront_distribution_id,
+            distribution_hostname=service_instance.cloudfront_origin_hostname,
+            cache_policy_id=cache_policy_id,
+            origin_request_policy_id=origin_request_policy_id,
+            compress=True,
+            allowed_methods=allowed_methods,
+            cached_methods=cached_methods,
+        )
+    if service_instance.instance_type == ServiceInstanceTypes.CDN_DEDICATED_WAF.value:
+        cloudfront.expect_update_distribution(
+            caller_reference="asdf",
+            domains=service_instance.domain_names,
+            certificate_id=service_instance.new_certificate.iam_server_certificate_id,
+            origin_hostname=service_instance.cloudfront_origin_hostname,
+            origin_path=service_instance.cloudfront_origin_path,
+            distribution_id=service_instance.cloudfront_distribution_id,
+            distribution_hostname=service_instance.cloudfront_origin_hostname,
+            dedicated_waf_web_acl_arn=service_instance.dedicated_waf_web_acl_arn,
+            cache_policy_id=cache_policy_id,
+            origin_request_policy_id=origin_request_policy_id,
+            compress=True,
+            allowed_methods=allowed_methods,
+            cached_methods=cached_methods,
+        )
+
+    cloudfront.expect_tag_resource(service_instance)
+
+    update_distribution.call_local(operation_id)
+
+    # asserts that all the mocked calls above were made
+    cloudfront.assert_no_pending_responses()
+
+    clean_db.session.expunge_all()
+
+    operation = clean_db.session.get(Operation, operation_id)
+    assert operation.step_description == "Updating CloudFront distribution"
+
+
+@pytest.mark.parametrize(
+    "instance_factory",
+    [
         factories.CDNDedicatedWAFServiceInstanceFactory,
     ],
 )

--- a/tests/lib/fake_cloudfront.py
+++ b/tests/lib/fake_cloudfront.py
@@ -89,6 +89,7 @@ class FakeCloudFront(FakeAWS):
         origin_request_policy_id: str = None,
         allowed_methods: list[str] = [],
         cached_methods: list[str] = [],
+        grpc_enabled: bool = None,
     ):
         if custom_error_responses is None:
             custom_error_responses = {"Quantity": 0}
@@ -117,6 +118,7 @@ class FakeCloudFront(FakeAWS):
                     origin_request_policy_id=origin_request_policy_id,
                     allowed_methods=allowed_methods,
                     cached_methods=cached_methods,
+                    grpc_enabled=grpc_enabled,
                 ),
                 "ETag": self.etag,
             },
@@ -309,6 +311,7 @@ class FakeCloudFront(FakeAWS):
         compress: bool = None,
         allowed_methods: list[str] = [],
         cached_methods: list[str] = [],
+        grpc_enabled: bool = None,
     ):
         self.stubber.add_response(
             "update_distribution",
@@ -346,6 +349,7 @@ class FakeCloudFront(FakeAWS):
                     compress=compress,
                     allowed_methods=allowed_methods,
                     cached_methods=cached_methods,
+                    grpc_enabled=grpc_enabled,
                 ),
                 "Id": distribution_id,
                 "IfMatch": self.etag,
@@ -467,6 +471,7 @@ class FakeCloudFront(FakeAWS):
         compress: bool = None,
         allowed_methods: list[str] = [],
         cached_methods: list[str] = [],
+        grpc_enabled: bool = None,
     ) -> Dict[str, Any]:
         if forwarded_headers is None:
             forwarded_headers = ["HOST"]
@@ -542,6 +547,15 @@ class FakeCloudFront(FakeAWS):
             default_cache_behavior.update(
                 {
                     "OriginRequestPolicyId": origin_request_policy_id,
+                }
+            )
+
+        if grpc_enabled:
+            default_cache_behavior.update(
+                {
+                    "GrpcConfig": {
+                        "Enabled": True,
+                    }
                 }
             )
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- [fix update_default_cache_behavior() to preserve managed cache policy and managed origin request policyfrom existing distribution config, even if no updates are specified to these values](https://github.com/cloud-gov/external-domain-broker/commit/bec2a8220d969f64ddf375f9e0a8ab3001d3feb7) 
- [add unit test to confirm that CDN updates preserve existing CDN configuration](https://github.com/cloud-gov/external-domain-broker/commit/90571fdfb4850991e47146f8f89bd38b77bd2825) 

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None. These code changes are not sensitive
