### PR TITLE
update retrieve_certificate task to cancel in failed state

### DIFF
--- a/tests/integration/tasks/test_letsencrypt.py
+++ b/tests/integration/tasks/test_letsencrypt.py
@@ -1,0 +1,38 @@
+import pytest
+
+from huey import CancelExecution
+
+from broker.tasks.letsencrypt import (
+    retrieve_certificate,
+)
+
+
+from tests.lib import factories
+
+
+@pytest.fixture
+def service_instance(clean_db, service_instance_id, operation_id):
+    service_instance = factories.CDNServiceInstanceFactory.create(
+        id=service_instance_id,
+        domain_names=["example.com"],
+        domain_internal="fake1234.cloudfront.net",
+        route53_alias_hosted_zone="Z2FDTNDATAQYW2",
+        cloudfront_distribution_id="FakeDistributionId",
+        cloudfront_origin_hostname="origin_hostname",
+        cloudfront_origin_path="origin_path",
+        origin_protocol_policy="https-only",
+        forwarded_headers=["HOST"],
+    )
+    clean_db.session.add(service_instance)
+    clean_db.session.commit()
+    factories.OperationFactory.create(
+        id=operation_id, service_instance=service_instance
+    )
+    return service_instance
+
+
+def test_retrieve_certificate_cancels(clean_db, service_instance, operation_id, dns):
+    dns.add_cname("_acme-challenge.example.com")
+
+    with pytest.raises(CancelExecution):
+        retrieve_certificate.call_local(operation_id)


### PR DESCRIPTION
## Changes proposed in this pull request:

When handling a `ValidationError` exception, the `retrieve_certificate` task code intentionally deletes `service_instance.new_certificate`:

https://github.com/cloud-gov/external-domain-broker/blob/12e11b14d60ccf4fa934f113218ebc11a7451161/broker/tasks/letsencrypt.py#L308-L318

Subsequent retries of the task then fail on this line: 

https://github.com/cloud-gov/external-domain-broker/blob/12e11b14d60ccf4fa934f113218ebc11a7451161/broker/tasks/letsencrypt.py#L261-L262

with an error like:

```
"AttributeError: 'NoneType' object has no attribute 'leaf_pem'"
```

The code is **intentionally causing this failure condition** so that the ask will fail on retry. After the task has failed 24 times, the pipeline will give up. And the pipeline will get restarted later for certificate renewal.

The problem is that the code spams our logs with error messages that are confusing. 

To keep the behavior the same but avoid the unnecessary error messages, this PR updates `retrieve_certificate` to raise a `CancelExecution` exception with retries disabled. [Raising this exception will stop the task and prevent further retries](https://huey.readthedocs.io/en/latest/guide.html#canceling-from-within-a-task), which is appropriate in this case since the service instance is now in an unrecoverable state. 

The net effect will still be that the pipeline for certificate renewal fails and is restarted later automatically.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None. The code changes are not sensitive.
