### PR TITLE
update WAF rules provisioned for domain-with-org-lb instances

### DIFF
--- a/broker/tasks/waf.py
+++ b/broker/tasks/waf.py
@@ -136,22 +136,6 @@ def _get_web_acl_rules(instance, web_acl_name: str):
     elif is_dedicated_alb(instance):
         return [
             {
-                "Name": "AWSManagedRule-CoreRuleSet",
-                "Priority": 0,
-                "Statement": {
-                    "ManagedRuleGroupStatement": {
-                        "VendorName": "AWS",
-                        "Name": "AWSManagedRulesCommonRuleSet",
-                    }
-                },
-                "OverrideAction": {"None": {}},
-                "VisibilityConfig": {
-                    "SampledRequestsEnabled": True,
-                    "CloudWatchMetricsEnabled": True,
-                    "MetricName": f"{web_acl_name}-AWS-AWSManagedRulesCommonRuleSet",
-                },
-            },
-            {
                 "Name": "AWS-AWSManagedRulesAnonymousIpList",
                 "Priority": 10,
                 "Statement": {

--- a/tests/lib/fake_wafv2.py
+++ b/tests/lib/fake_wafv2.py
@@ -59,22 +59,6 @@ class FakeWAFV2(FakeAWS):
             "DefaultAction": {"Allow": {}},
             "Rules": [
                 {
-                    "Name": "AWSManagedRule-CoreRuleSet",
-                    "Priority": 0,
-                    "Statement": {
-                        "ManagedRuleGroupStatement": {
-                            "VendorName": "AWS",
-                            "Name": "AWSManagedRulesCommonRuleSet",
-                        }
-                    },
-                    "OverrideAction": {"None": {}},
-                    "VisibilityConfig": {
-                        "SampledRequestsEnabled": True,
-                        "CloudWatchMetricsEnabled": True,
-                        "MetricName": f"{waf_name}-AWS-AWSManagedRulesCommonRuleSet",
-                    },
-                },
-                {
                     "Name": "AWS-AWSManagedRulesAnonymousIpList",
                     "Priority": 10,
                     "Statement": {


### PR DESCRIPTION
## Changes proposed in this pull request:

- update WAF rules provisioned for domain-with-org-lb instances to remove duplicate inclusion of `AWSManagedRule-CoreRuleSet`

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None. Just fixing a bug in the provisioning of WAF rules for `domain-with-org-lb` instances
