### PR TITLE
Wait for web ACL on creation before associating

### DIFF
--- a/broker/app.py
+++ b/broker/app.py
@@ -18,6 +18,7 @@ from broker.commands.duplicate_certs import (
     log_duplicate_alb_cert_metrics,
     remove_duplicate_alb_certs,
 )
+from broker.commands.tags import add_dedicated_alb_tags
 from broker.commands.waf import add_dedicated_alb_waf_web_acls
 from broker.extensions import config, db, migrate
 from broker.errors import handle_exception
@@ -86,5 +87,9 @@ def create_app():
     @app.cli.command("add-dedicated-alb-waf-web-acls")
     def add_dedicated_alb_waf_web_acls_command():
         add_dedicated_alb_waf_web_acls()
+
+    @app.cli.command("add-dedicated-alb-tags")
+    def add_dedicated_alb_tags_command():
+        add_dedicated_alb_tags()
 
     return app

--- a/broker/commands/tags.py
+++ b/broker/commands/tags.py
@@ -1,5 +1,6 @@
 import logging
 
+from broker.aws import wafv2_govcloud
 from broker.extensions import config, db
 from broker.lib.tags import create_resource_tags, generate_tags
 from broker.models import DedicatedALB
@@ -30,3 +31,12 @@ def add_dedicated_alb_tags():
         dedicated_alb.tags = tags
         db.session.add(dedicated_alb)
         db.session.commit()
+
+        if not dedicated_alb.dedicated_waf_web_acl_arn:
+            logger.info("Web ACL ARN is required")
+            continue
+
+        wafv2_govcloud.tag_resource(
+            ResourceARN=dedicated_alb.dedicated_waf_web_acl_arn,
+            Tags=tags,
+        )

--- a/broker/commands/tags.py
+++ b/broker/commands/tags.py
@@ -1,0 +1,32 @@
+import logging
+
+from broker.extensions import config, db
+from broker.lib.tags import create_resource_tags, generate_tags
+from broker.models import DedicatedALB
+
+logger = logging.getLogger(__name__)
+
+
+def add_dedicated_alb_tags():
+    dedicated_albs = DedicatedALB.query.all()
+
+    for dedicated_alb in dedicated_albs:
+        if dedicated_alb.tags:
+            continue
+
+        if not dedicated_alb.dedicated_org:
+            logger.info(
+                "Organization ID is required to generate tags for dedicated ALB"
+            )
+            continue
+
+        tags = create_resource_tags(
+            generate_tags(
+                config.FLASK_ENV,
+                organization_guid=dedicated_alb.dedicated_org,
+            )
+        )
+
+        dedicated_alb.tags = tags
+        db.session.add(dedicated_alb)
+        db.session.commit()

--- a/broker/commands/waf.py
+++ b/broker/commands/waf.py
@@ -14,20 +14,22 @@ from broker.tasks.waf import (
 logger = logging.getLogger(__name__)
 
 
-def wait_for_web_acl_to_exist(waf_web_acl_arn):
+def wait_for_web_acl_to_exist(
+    waf_client, waf_web_acl_arn, retry_maximum_attempts, retry_delay_time
+):
     web_acl_exists = False
     num_times = 0
 
     while not web_acl_exists:
         num_times += 1
-        if num_times > config.AWS_POLL_MAX_ATTEMPTS:
+        if num_times > retry_maximum_attempts:
             raise RuntimeError(
-                f"Reached maximum attempts {config.AWS_POLL_MAX_ATTEMPTS} waiting for web ACL to exist"
+                f"Reached maximum attempts {retry_maximum_attempts} waiting for web ACL to exist"
             )
 
-        time.sleep(config.AWS_POLL_WAIT_TIME_IN_SECONDS)
+        time.sleep(retry_delay_time)
         try:
-            wafv2_govcloud.get_web_acl(ARN=waf_web_acl_arn)
+            waf_client.get_web_acl(ARN=waf_web_acl_arn)
             web_acl_exists = True
         except wafv2_govcloud.exceptions.WAFNonexistentItemException:
             continue
@@ -46,7 +48,12 @@ def add_dedicated_alb_waf_web_acls():
             continue
 
         create_web_acl(wafv2_govcloud, db, dedicated_alb)
-        wait_for_web_acl_to_exist(dedicated_alb.dedicated_waf_web_acl_arn)
+        wait_for_web_acl_to_exist(
+            wafv2_govcloud,
+            dedicated_alb.dedicated_waf_web_acl_arn,
+            config.AWS_POLL_MAX_ATTEMPTS,
+            config.AWS_POLL_WAIT_TIME_IN_SECONDS,
+        )
         put_waf_logging_configuration(
             wafv2_govcloud, dedicated_alb, config.ALB_WAF_CLOUDWATCH_LOG_GROUP_ARN
         )

--- a/broker/commands/waf.py
+++ b/broker/commands/waf.py
@@ -1,3 +1,6 @@
+import logging
+import time
+
 from broker.aws import wafv2_govcloud
 from broker.extensions import config, db
 from broker.models import DedicatedALB
@@ -6,6 +9,28 @@ from broker.tasks.waf import (
     put_waf_logging_configuration,
     associate_web_acl,
 )
+
+
+logger = logging.getLogger(__name__)
+
+
+def wait_for_web_acl_to_exist(waf_web_acl_arn):
+    web_acl_exists = False
+    num_times = 0
+
+    while not web_acl_exists:
+        num_times += 1
+        if num_times > config.AWS_POLL_MAX_ATTEMPTS:
+            raise RuntimeError(
+                f"Reached maximum attempts {config.AWS_POLL_MAX_ATTEMPTS} waiting for web ACL to exist"
+            )
+
+        time.sleep(config.AWS_POLL_WAIT_TIME_IN_SECONDS)
+        try:
+            wafv2_govcloud.get_web_acl(ARN=waf_web_acl_arn)
+            web_acl_exists = True
+        except wafv2_govcloud.exceptions.WAFNonexistentItemException:
+            continue
 
 
 def add_dedicated_alb_waf_web_acls():
@@ -21,6 +46,7 @@ def add_dedicated_alb_waf_web_acls():
             continue
 
         create_web_acl(wafv2_govcloud, db, dedicated_alb)
+        wait_for_web_acl_to_exist(dedicated_alb.dedicated_waf_web_acl_arn)
         put_waf_logging_configuration(
             wafv2_govcloud, dedicated_alb, config.ALB_WAF_CLOUDWATCH_LOG_GROUP_ARN
         )

--- a/tests/integration/cdn_dedicated_waf/test_cdn_dedicated_waf_deprovisioning.py
+++ b/tests/integration/cdn_dedicated_waf/test_cdn_dedicated_waf_deprovisioning.py
@@ -312,8 +312,8 @@ def subtest_deprovision_delete_web_acl_success_when_missing(
     db.session.expunge_all()
     service_instance = db.session.get(instance_model, "1234")
     wafv2.expect_get_web_acl_not_found(
-        service_instance.dedicated_waf_web_acl_id,
-        service_instance.dedicated_waf_web_acl_name,
+        id=service_instance.dedicated_waf_web_acl_id,
+        name=service_instance.dedicated_waf_web_acl_name,
     )
 
     tasks.run_queued_tasks_and_enqueue_dependents()
@@ -393,8 +393,8 @@ def subtest_deprovision_deletes_web_acl(instance_model, tasks, service_instance,
     assert service_instance.dedicated_waf_web_acl_name == "1234-dedicated-waf"
 
     wafv2.expect_get_web_acl(
-        service_instance.dedicated_waf_web_acl_id,
-        service_instance.dedicated_waf_web_acl_name,
+        id=service_instance.dedicated_waf_web_acl_id,
+        name=service_instance.dedicated_waf_web_acl_name,
     )
     wafv2.expect_delete_web_acl(
         service_instance.dedicated_waf_web_acl_id,

--- a/tests/integration/cdn_dedicated_waf/test_cdn_dedicated_waf_deprovisioning.py
+++ b/tests/integration/cdn_dedicated_waf/test_cdn_dedicated_waf_deprovisioning.py
@@ -314,6 +314,7 @@ def subtest_deprovision_delete_web_acl_success_when_missing(
     wafv2.expect_get_web_acl_not_found(
         id=service_instance.dedicated_waf_web_acl_id,
         name=service_instance.dedicated_waf_web_acl_name,
+        scope="CLOUDFRONT",
     )
 
     tasks.run_queued_tasks_and_enqueue_dependents()
@@ -395,6 +396,7 @@ def subtest_deprovision_deletes_web_acl(instance_model, tasks, service_instance,
     wafv2.expect_get_web_acl(
         id=service_instance.dedicated_waf_web_acl_id,
         name=service_instance.dedicated_waf_web_acl_name,
+        scope="CLOUDFRONT",
     )
     wafv2.expect_delete_web_acl(
         service_instance.dedicated_waf_web_acl_id,

--- a/tests/integration/commands/test_tags.py
+++ b/tests/integration/commands/test_tags.py
@@ -9,9 +9,14 @@ from tests.lib.tags import sort_instance_tags
 
 
 @pytest.fixture
-def dedicated_alb(clean_db, dedicated_alb_id, dedicated_alb_arn, organization_guid):
+def dedicated_alb(
+    clean_db, dedicated_alb_id, dedicated_alb_arn, organization_guid, waf_web_acl_arn
+):
     dedicated_alb = factories.DedicatedALBFactory.create(
-        id=dedicated_alb_id, alb_arn=dedicated_alb_arn, dedicated_org=organization_guid
+        id=dedicated_alb_id,
+        alb_arn=dedicated_alb_arn,
+        dedicated_org=organization_guid,
+        dedicated_waf_web_acl_arn=waf_web_acl_arn,
     )
 
     clean_db.session.add(dedicated_alb)
@@ -27,6 +32,7 @@ def test_add_dedicated_alb_tags(
     access_token,
     mock_with_uaa_auth,
     organization_guid,
+    wafv2_govcloud,
 ):
 
     response = json.dumps({"guid": organization_guid, "name": "org-1234"})
@@ -40,18 +46,65 @@ def test_add_dedicated_alb_tags(
 
     assert not dedicated_alb.tags
 
+    expected_tags = [
+        {"Key": "client", "Value": "Cloud Foundry"},
+        {"Key": "broker", "Value": "External domain broker"},
+        {"Key": "environment", "Value": config.FLASK_ENV},
+        {"Key": "Organization GUID", "Value": organization_guid},
+        {"Key": "Organization name", "Value": "org-1234"},
+    ]
+
+    wafv2_govcloud.expect_tag_resource(
+        dedicated_alb.dedicated_waf_web_acl_arn, expected_tags
+    )
+
     add_dedicated_alb_tags()
+
+    wafv2_govcloud.assert_no_pending_responses()
 
     clean_db.session.expunge_all()
 
     dedicated_alb = clean_db.session.get(DedicatedALB, dedicated_alb_id)
 
-    assert sort_instance_tags(dedicated_alb.tags) == sort_instance_tags(
-        [
-            {"Key": "client", "Value": "Cloud Foundry"},
-            {"Key": "broker", "Value": "External domain broker"},
-            {"Key": "environment", "Value": config.FLASK_ENV},
-            {"Key": "Organization GUID", "Value": organization_guid},
-            {"Key": "Organization name", "Value": "org-1234"},
-        ]
+    assert sort_instance_tags(dedicated_alb.tags) == sort_instance_tags(expected_tags)
+
+
+def test_add_dedicated_alb_tags_does_nothing_existing_tags(
+    clean_db,
+    dedicated_alb,
+    wafv2_govcloud,
+):
+
+    dedicated_alb.tags = [{"foo": "bar"}]
+    clean_db.session.add(dedicated_alb)
+    clean_db.session.commit()
+
+    add_dedicated_alb_tags()
+
+    wafv2_govcloud.assert_no_pending_responses()
+
+
+def test_add_dedicated_alb_tags_requires_waf_arn(
+    clean_db,
+    dedicated_alb,
+    wafv2_govcloud,
+    organization_guid,
+    mock_with_uaa_auth,
+    access_token,
+):
+    dedicated_alb.dedicated_waf_web_acl_arn = None
+    clean_db.session.add(dedicated_alb)
+    clean_db.session.commit()
+
+    response = json.dumps({"guid": organization_guid, "name": "org-1234"})
+    mock_with_uaa_auth.get(
+        f"http://mock.cf/v3/organizations/{organization_guid}",
+        text=response,
+        request_headers={
+            "Authorization": f"Bearer {access_token}",
+        },
     )
+
+    add_dedicated_alb_tags()
+
+    wafv2_govcloud.assert_no_pending_responses()

--- a/tests/integration/commands/test_tags.py
+++ b/tests/integration/commands/test_tags.py
@@ -1,0 +1,57 @@
+import json
+import pytest
+
+from broker.commands.tags import add_dedicated_alb_tags
+from broker.extensions import config
+from broker.models import DedicatedALB
+from tests.lib import factories
+from tests.lib.tags import sort_instance_tags
+
+
+@pytest.fixture
+def dedicated_alb(clean_db, dedicated_alb_id, dedicated_alb_arn, organization_guid):
+    dedicated_alb = factories.DedicatedALBFactory.create(
+        id=dedicated_alb_id, alb_arn=dedicated_alb_arn, dedicated_org=organization_guid
+    )
+
+    clean_db.session.add(dedicated_alb)
+    clean_db.session.commit()
+
+    return dedicated_alb
+
+
+def test_add_dedicated_alb_tags(
+    clean_db,
+    dedicated_alb,
+    dedicated_alb_id,
+    access_token,
+    mock_with_uaa_auth,
+    organization_guid,
+):
+
+    response = json.dumps({"guid": organization_guid, "name": "org-1234"})
+    mock_with_uaa_auth.get(
+        f"http://mock.cf/v3/organizations/{organization_guid}",
+        text=response,
+        request_headers={
+            "Authorization": f"Bearer {access_token}",
+        },
+    )
+
+    assert not dedicated_alb.tags
+
+    add_dedicated_alb_tags()
+
+    clean_db.session.expunge_all()
+
+    dedicated_alb = clean_db.session.get(DedicatedALB, dedicated_alb_id)
+
+    assert sort_instance_tags(dedicated_alb.tags) == sort_instance_tags(
+        [
+            {"Key": "client", "Value": "Cloud Foundry"},
+            {"Key": "broker", "Value": "External domain broker"},
+            {"Key": "environment", "Value": config.FLASK_ENV},
+            {"Key": "Organization GUID", "Value": organization_guid},
+            {"Key": "Organization name", "Value": "org-1234"},
+        ]
+    )

--- a/tests/integration/commands/test_waf.py
+++ b/tests/integration/commands/test_waf.py
@@ -11,28 +11,12 @@ from tests.lib import factories
 
 
 @pytest.fixture
-def dedicated_alb(
-    clean_db, dedicated_alb_id, service_instance_id, operation_id, dedicated_alb_arn
-):
+def dedicated_alb(clean_db, dedicated_alb_id, dedicated_alb_arn):
     dedicated_alb = factories.DedicatedALBFactory.create(
         id=dedicated_alb_id, alb_arn=dedicated_alb_arn, dedicated_org="org-1"
     )
-
-    service_instance = factories.DedicatedALBServiceInstanceFactory.create(
-        id=service_instance_id,
-        org_id="org-1",
-        alb_arn=dedicated_alb_arn,
-        alb_listener_arn="listener-1",
-    )
-
     clean_db.session.add(dedicated_alb)
-    clean_db.session.add(service_instance)
     clean_db.session.commit()
-
-    factories.OperationFactory.create(
-        id=operation_id, service_instance=service_instance
-    )
-
     return dedicated_alb
 
 

--- a/tests/integration/tasks/test_waf.py
+++ b/tests/integration/tasks/test_waf.py
@@ -382,8 +382,9 @@ def test_waf_delete_web_acl_gives_up_after_max_retries(
 
     for i in range(10):
         wafv2_commercial.expect_get_web_acl(
-            service_instance.dedicated_waf_web_acl_id,
-            service_instance.dedicated_waf_web_acl_name,
+            id=service_instance.dedicated_waf_web_acl_id,
+            name=service_instance.dedicated_waf_web_acl_name,
+            scope="CLOUDFRONT",
         )
         wafv2_commercial.expect_delete_web_acl_lock_exception(
             service_instance.dedicated_waf_web_acl_id,
@@ -426,16 +427,18 @@ def test_waf_delete_web_acl_succeeds_on_retry(
     )
 
     wafv2_commercial.expect_get_web_acl(
-        service_instance.dedicated_waf_web_acl_id,
-        service_instance.dedicated_waf_web_acl_name,
+        id=service_instance.dedicated_waf_web_acl_id,
+        name=service_instance.dedicated_waf_web_acl_name,
+        scope="CLOUDFRONT",
     )
     wafv2_commercial.expect_delete_web_acl_lock_exception(
         service_instance.dedicated_waf_web_acl_id,
         service_instance.dedicated_waf_web_acl_name,
     )
     wafv2_commercial.expect_get_web_acl(
-        service_instance.dedicated_waf_web_acl_id,
-        service_instance.dedicated_waf_web_acl_name,
+        id=service_instance.dedicated_waf_web_acl_id,
+        name=service_instance.dedicated_waf_web_acl_name,
+        scope="CLOUDFRONT",
     )
     wafv2_commercial.expect_delete_web_acl(
         service_instance.dedicated_waf_web_acl_id,

--- a/tests/lib/fake_wafv2.py
+++ b/tests/lib/fake_wafv2.py
@@ -238,6 +238,17 @@ class FakeWAFV2(FakeAWS):
         response = {}
         self.stubber.add_response(method, response, request)
 
+    def expect_tag_resource(self, resource_arn: str, tags: list[Tag]):
+        method = "tag_resource"
+
+        request = {
+            "ResourceARN": resource_arn,
+            "Tags": tags,
+        }
+
+        response = {}
+        self.stubber.add_response(method, response, request)
+
 
 @pytest.fixture(autouse=True)
 def wafv2_commercial():

--- a/tests/lib/fake_wafv2.py
+++ b/tests/lib/fake_wafv2.py
@@ -152,30 +152,47 @@ class FakeWAFV2(FakeAWS):
 
         self.stubber.add_response(method, {}, request)
 
-    def expect_get_web_acl(self, id: str, name: str):
+    def expect_get_web_acl(
+        self, id: str = "", name: str = "", arn: str = "", scope: str = ""
+    ):
+        params = {}
+        if id:
+            params["Id"] = id
+
+        if name:
+            params["Name"] = name
+
+        if arn:
+            params["ARN"] = arn
+
+        if scope:
+            params["Scope"] = scope
+
         self.stubber.add_response(
             "get_web_acl",
             {
                 "LockToken": "fake-token",
             },
-            {
-                "Name": name,
-                "Id": id,
-                "Scope": "CLOUDFRONT",
-            },
+            params,
         )
 
-    def expect_get_web_acl_not_found(self, id: str, name: str):
+    def expect_get_web_acl_not_found(self, id: str = "", name: str = "", arn: str = ""):
+        params = {}
+        if id:
+            params["Id"] = id
+
+        if name:
+            params["Name"] = name
+
+        if arn:
+            params["ARN"] = arn
+
         self.stubber.add_client_error(
             "get_web_acl",
             service_error_code="WAFNonexistentItemException",
             service_message="Not found",
             http_status_code=404,
-            expected_params={
-                "Name": name,
-                "Id": id,
-                "Scope": "CLOUDFRONT",
-            },
+            expected_params=params,
         )
 
     def expect_delete_web_acl_lock_exception(self, id: str, name: str):

--- a/tests/lib/fake_wafv2.py
+++ b/tests/lib/fake_wafv2.py
@@ -176,7 +176,9 @@ class FakeWAFV2(FakeAWS):
             params,
         )
 
-    def expect_get_web_acl_not_found(self, id: str = "", name: str = "", arn: str = ""):
+    def expect_get_web_acl_not_found(
+        self, id: str = "", name: str = "", arn: str = "", scope: str = ""
+    ):
         params = {}
         if id:
             params["Id"] = id
@@ -186,6 +188,9 @@ class FakeWAFV2(FakeAWS):
 
         if arn:
             params["ARN"] = arn
+
+        if scope:
+            params["Scope"] = scope
 
         self.stubber.add_client_error(
             "get_web_acl",


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update `add_dedicated_alb_waf_web_acls` to wait for web ACL creation to finish before attempting to associate it
- Add `add_dedicated_alb_tags` command to set tags on web ACLs
- Add/update tests for new behaviors


## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None. The code changes are not sensitive
