### PR TITLE
Update associate WAF web ACL logic

### DIFF
--- a/broker/app.py
+++ b/broker/app.py
@@ -22,7 +22,7 @@ from broker.commands.duplicate_certs import (
 from broker.commands.tags import add_dedicated_alb_tags
 from broker.commands.waf import (
     create_dedicated_alb_waf_web_acls,
-    associate_dedicated_alb_waf_web_acls,
+    update_dedicated_alb_waf_web_acls,
 )
 from broker.extensions import config, db, migrate
 from broker.errors import handle_exception
@@ -95,9 +95,9 @@ def create_app():
     def create_dedicated_alb_waf_web_acls_command(force_create_new):
         create_dedicated_alb_waf_web_acls(force_create_new)
 
-    @app.cli.command("associate-dedicated-alb-waf-web-acls")
-    def associate_dedicated_alb_waf_web_acls_command():
-        associate_dedicated_alb_waf_web_acls()
+    @app.cli.command("update-dedicated-alb-waf-web-acls")
+    def update_dedicated_alb_waf_web_acls_command():
+        update_dedicated_alb_waf_web_acls()
 
     @app.cli.command("add-dedicated-alb-tags")
     def add_dedicated_alb_tags_command():

--- a/broker/commands/waf.py
+++ b/broker/commands/waf.py
@@ -60,7 +60,7 @@ def create_dedicated_alb_waf_web_acls(force_create_new=False):
         )
 
 
-def associate_dedicated_alb_waf_web_acls():
+def update_dedicated_alb_waf_web_acls():
     dedicated_albs = DedicatedALB.query.all()
 
     for dedicated_alb in dedicated_albs:

--- a/tests/integration/cdn_dedicated_waf/test_cdn_dedicated_waf_deprovisioning.py
+++ b/tests/integration/cdn_dedicated_waf/test_cdn_dedicated_waf_deprovisioning.py
@@ -401,6 +401,7 @@ def subtest_deprovision_deletes_web_acl(instance_model, tasks, service_instance,
     wafv2.expect_delete_web_acl(
         service_instance.dedicated_waf_web_acl_id,
         service_instance.dedicated_waf_web_acl_name,
+        "CLOUDFRONT",
     )
 
     tasks.run_queued_tasks_and_enqueue_dependents()

--- a/tests/integration/commands/test_waf.py
+++ b/tests/integration/commands/test_waf.py
@@ -288,3 +288,21 @@ def test_wait_for_associated_waf_web_acl_arn(
     )
 
     wafv2_govcloud.assert_no_pending_responses()
+
+
+def test_wait_for_associated_waf_web_acl_arn_gives_up(
+    clean_db,
+    dedicated_alb,
+    wafv2_govcloud,
+):
+    for i in range(10):
+        wafv2_govcloud.expect_get_web_acl_for_resource(
+            dedicated_alb.alb_arn, "different-waf"
+        )
+
+    with pytest.raises(RuntimeError):
+        wait_for_associated_waf_web_acl_arn(
+            dedicated_alb.alb_arn, generate_fake_waf_web_acl_arn("1234-dedicated-waf")
+        )
+
+    wafv2_govcloud.assert_no_pending_responses()

--- a/tests/integration/commands/test_waf.py
+++ b/tests/integration/commands/test_waf.py
@@ -3,7 +3,7 @@ import pytest
 from broker.commands.waf import (
     create_dedicated_alb_waf_web_acls,
     wait_for_web_acl_to_exist,
-    associate_dedicated_alb_waf_web_acls,
+    update_dedicated_alb_waf_web_acls,
 )
 from broker.tasks.waf import generate_web_acl_name
 from broker.aws import wafv2_govcloud as real_wafv2_govcloud
@@ -195,7 +195,7 @@ def test_associate_dedicated_alb_updates_waf_web_acls(
         dedicated_alb.alb_arn,
     )
 
-    associate_dedicated_alb_waf_web_acls()
+    update_dedicated_alb_waf_web_acls()
 
     wafv2_govcloud.assert_no_pending_responses()
 
@@ -215,7 +215,7 @@ def test_associate_dedicated_alb_updates_waf_web_acls(
 def test_associate_dedicated_alb_has_no_waf_web_acl(
     clean_db, dedicated_alb_id, dedicated_alb, wafv2_govcloud
 ):
-    associate_dedicated_alb_waf_web_acls()
+    update_dedicated_alb_waf_web_acls()
 
     wafv2_govcloud.assert_no_pending_responses()
 
@@ -252,7 +252,7 @@ def test_associate_dedicated_alb_does_not_update_waf_web_acls(
         dedicated_alb.alb_arn, dedicated_alb.dedicated_waf_web_acl_name
     )
 
-    associate_dedicated_alb_waf_web_acls()
+    update_dedicated_alb_waf_web_acls()
 
     wafv2_govcloud.assert_no_pending_responses()
 

--- a/tests/integration/commands/test_waf.py
+++ b/tests/integration/commands/test_waf.py
@@ -181,9 +181,13 @@ def test_associate_dedicated_alb_updates_waf_web_acls(
     dedicated_alb,
     wafv2_govcloud,
 ):
-    dedicated_alb.dedicated_waf_web_acl_id = "1234"
     dedicated_alb.dedicated_waf_web_acl_name = "1234-dedicated-waf"
-    dedicated_alb.dedicated_waf_web_acl_arn = "1234-dedicated-waf-arn"
+    dedicated_alb.dedicated_waf_web_acl_arn = generate_fake_waf_web_acl_arn(
+        dedicated_alb.dedicated_waf_web_acl_name
+    )
+    dedicated_alb.dedicated_waf_web_acl_id = generate_fake_waf_web_acl_id(
+        dedicated_alb.dedicated_waf_web_acl_name
+    )
     clean_db.session.add(dedicated_alb)
     clean_db.session.commit()
 
@@ -193,6 +197,9 @@ def test_associate_dedicated_alb_updates_waf_web_acls(
     wafv2_govcloud.expect_alb_associate_web_acl(
         dedicated_alb.dedicated_waf_web_acl_arn,
         dedicated_alb.alb_arn,
+    )
+    wafv2_govcloud.expect_get_web_acl_for_resource(
+        dedicated_alb.alb_arn, "1234-dedicated-waf"
     )
 
     update_dedicated_alb_waf_web_acls()
@@ -206,8 +213,12 @@ def test_associate_dedicated_alb_updates_waf_web_acls(
         dedicated_alb_id,
     )
 
-    assert service_instance.dedicated_waf_web_acl_arn == "1234-dedicated-waf-arn"
-    assert service_instance.dedicated_waf_web_acl_id == "1234"
+    assert service_instance.dedicated_waf_web_acl_arn == generate_fake_waf_web_acl_arn(
+        dedicated_alb.dedicated_waf_web_acl_name
+    )
+    assert service_instance.dedicated_waf_web_acl_id == generate_fake_waf_web_acl_id(
+        dedicated_alb.dedicated_waf_web_acl_name
+    )
     assert service_instance.dedicated_waf_web_acl_name == "1234-dedicated-waf"
     assert service_instance.dedicated_waf_associated == True
 

--- a/tests/integration/tasks/test_waf.py
+++ b/tests/integration/tasks/test_waf.py
@@ -449,6 +449,26 @@ def test_waf_create_web_acl_force_new_create(
     assert service_instance.dedicated_waf_web_acl_name == dedicated_alb_waf_name
 
 
+def test_associate_web_acl_no_web_acl_arn(
+    clean_db,
+    dedicated_alb,
+    wafv2_govcloud,
+):
+    waf.associate_web_acl(real_wafv2_govcloud, clean_db, dedicated_alb, None, None)
+
+    wafv2_govcloud.assert_no_pending_responses()
+
+
+def test_associate_web_acl_no_resource_arn(
+    clean_db,
+    dedicated_alb,
+    wafv2_govcloud,
+):
+    waf.associate_web_acl(real_wafv2_govcloud, clean_db, dedicated_alb, "arn-1", None)
+
+    wafv2_govcloud.assert_no_pending_responses()
+
+
 def test_waf_associate_alb_web_acl(
     clean_db,
     operation_id,

--- a/tests/lib/fake_wafv2.py
+++ b/tests/lib/fake_wafv2.py
@@ -200,6 +200,27 @@ class FakeWAFV2(FakeAWS):
             expected_params=params,
         )
 
+    def expect_get_web_acl_for_resource(self, resource_arn: str, waf_name: str):
+        self.stubber.add_response(
+            "get_web_acl_for_resource",
+            {
+                "WebACL": {
+                    "Name": waf_name,
+                    "ARN": generate_fake_waf_web_acl_arn(waf_name),
+                    "Id": generate_fake_waf_web_acl_id(waf_name),
+                    "DefaultAction": {
+                        "Allow": {},
+                    },
+                    "VisibilityConfig": {
+                        "SampledRequestsEnabled": True,
+                        "CloudWatchMetricsEnabled": True,
+                        "MetricName": f"{waf_name}-metric",
+                    },
+                }
+            },
+            {"ResourceArn": resource_arn},
+        )
+
     def expect_delete_web_acl_lock_exception(self, id: str, name: str):
         self.stubber.add_client_error(
             "delete_web_acl",

--- a/tests/lib/fake_wafv2.py
+++ b/tests/lib/fake_wafv2.py
@@ -235,11 +235,11 @@ class FakeWAFV2(FakeAWS):
             },
         )
 
-    def expect_delete_web_acl(self, id: str, name: str):
+    def expect_delete_web_acl(self, id: str, name: str, scope: str):
         self.stubber.add_response(
             "delete_web_acl",
             {},
-            {"Name": name, "Id": id, "Scope": "CLOUDFRONT", "LockToken": "fake-token"},
+            {"Name": name, "Id": id, "Scope": scope, "LockToken": "fake-token"},
         )
 
     def expect_put_logging_configuration(self, resource_arn: str, log_group_arn: str):


### PR DESCRIPTION
## Changes proposed in this pull request:

Follow-up to #442. When updating a dedicated org load balancer to **one WAF web ACL to be shared by all load balancers for an organization, rather than one WAF web ACL for each of the load balancers**, we need to clean up the old WAF web ACL that was shared by all the load balancers.

This PR implements the logic to delete the obsolete WAF web ACL once the new one is associated.

- Rename `associate-dedicated-alb-waf-web-acls` to `update-dedicated-alb-waf-web-acls`
- Update logic for `update-dedicated-alb-waf-web-acls` to:
  - Associate new web ACL tracked by database only if it is not already associated with the ALB
  - Wait to confirm that new web ACL has been associated with ALB
  - Delete the obsolete web ACL no longer associated with the ALB
- Update tests for new behavior

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None. There is no change in the behavior of the web ACLs, this is just utility code for handling the creation and association of new web ACLs with dedicated ALBs.