### PR TITLE
Fix command to create WAF web ACLs for dedicated ALBs

### DIFF
--- a/broker/commands/waf.py
+++ b/broker/commands/waf.py
@@ -40,7 +40,7 @@ def wait_for_web_acl_to_exist(
             continue
 
 
-def update_dedicated_alb_web_acl_info(waf_client: WAFV2Client, dedicated_alb):
+def update_dedicated_alb_with_web_acl_info(waf_client: WAFV2Client, dedicated_alb):
     response = waf_client.list_web_acls(Scope="REGIONAL")
     waf_web_acl_name = generate_web_acl_name(dedicated_alb, config.AWS_RESOURCE_PREFIX)
     filtered_web_acls = [
@@ -88,7 +88,7 @@ def create_dedicated_alb_waf_web_acls(force_create_new=False):
         # If the web ACL for this dedicated ALB had previously been created, it is not created
         # again, so we need to manually update the dedicated ALB record with the web ACL info
         if already_exists:
-            update_dedicated_alb_web_acl_info(wafv2_govcloud, dedicated_alb)
+            update_dedicated_alb_with_web_acl_info(wafv2_govcloud, dedicated_alb)
         else:
             wait_for_web_acl_to_exist(
                 wafv2_govcloud,

--- a/broker/commands/waf.py
+++ b/broker/commands/waf.py
@@ -50,17 +50,17 @@ def update_dedicated_alb_web_acl_info(waf_client: WAFV2Client, dedicated_alb):
     ]
 
     if len(filtered_web_acls) == 0:
-        return RuntimeError("Could not find web ACL")
+        raise RuntimeError("Could not find web ACL")
 
     web_acl = filtered_web_acls[0]
     if "ARN" not in web_acl:
-        return RuntimeError("Could not get ARN from web ACL")
+        raise RuntimeError("Could not get ARN from web ACL")
 
     if "Id" not in web_acl:
-        return RuntimeError("Could not get ID from web ACL")
+        raise RuntimeError("Could not get ID from web ACL")
 
     if "Name" not in web_acl:
-        return RuntimeError("Could not get name from web ACL")
+        raise RuntimeError("Could not get name from web ACL")
 
     dedicated_alb.dedicated_waf_web_acl_arn = web_acl["ARN"]
     dedicated_alb.dedicated_waf_web_acl_id = web_acl["Id"]

--- a/broker/config.py
+++ b/broker/config.py
@@ -28,6 +28,67 @@ def config_from_env() -> Type["Config"]:
 
 
 class Config:
+    ACME_DIRECTORY: str
+    ACME_POLL_TIMEOUT_IN_SECONDS: int
+    ALB_IAM_SERVER_CERTIFICATE_PREFIX: str
+    ALB_LISTENER_ARNS: list[str]
+    ALB_OVERLAP_SLEEP_TIME: int
+    ALB_WAF_CLOUDWATCH_LOG_GROUP_ARN: str
+    ALLOWED_AWS_MANAGED_CACHE_POLICIES: list[str]
+    ALLOWED_AWS_MANAGED_ORIGIN_VIEWER_REQUEST_POLICIES: list[str]
+    AWS_COMMERCIAL_ACCESS_KEY_ID: str
+    AWS_COMMERCIAL_GLOBAL_REGION: str
+    AWS_COMMERCIAL_REGION: str
+    AWS_COMMERCIAL_SECRET_ACCESS_KEY: str
+    AWS_GOVCLOUD_ACCESS_KEY_ID: str
+    AWS_GOVCLOUD_REGION: str
+    AWS_GOVCLOUD_SECRET_ACCESS_KEY: str
+    AWS_RESOURCE_PREFIX: str
+    AWS_POLL_MAX_ATTEMPTS: int
+    AWS_POLL_WAIT_TIME_IN_SECONDS: int
+    BROKER_PASSWORD: str
+    BROKER_USERNAME: str
+    CDN_LOG_BUCKET: str
+    CDN_WAF_CLOUDWATCH_LOG_GROUP_ARN: str
+    CF_API_URL: str
+    CLOUDFRONT_HOSTED_ZONE_ID: str
+    CLOUDFRONT_IAM_SERVER_CERTIFICATE_PREFIX: str
+    DEBUG: bool
+    DEFAULT_CLOUDFRONT_ORIGIN: str
+    DATABASE_ENCRYPTION_KEY: str
+    DEDICATED_ALB_LISTENER_ARN_MAP: dict | list
+    DELETE_WEB_ACL_WAIT_RETRY_TIME: int
+    DNS_ROOT_DOMAIN: str
+    DNS_VERIFICATION_SERVER: str
+    DNS_PROPAGATION_SLEEP_TIME: int
+    IGNORE_DUPLICATE_DOMAINS: bool
+    FLASK_ENV: str
+    MAX_CERTS_PER_ALB: int
+    REDIS_HOST: str
+    REDIS_PASSWORD: str
+    REDIS_PORT: int
+    REDIS_SSL: bool
+    REQUEST_TIMEOUT: int
+    ROUTE53_ZONE_ID: str
+    SECRET_KEY: str
+    SQLALCHEMY_TRACK_MODIFICATIONS: bool
+    SECRET_KEY: str
+    SMTP_HOST: str
+    SMTP_FROM: str
+    SMTP_CERT: str
+    SMTP_USER: str
+    SMTP_PASS: str
+    SMTP_PORT: int
+    SMTP_TO: str
+    SMTP_TLS: bool
+    SQLALCHEMY_DATABASE_URI: str
+    TESTING: bool
+    UAA_BASE_URL: str
+    UAA_CLIENT_ID: str
+    UAA_CLIENT_SECRET: str
+    UAA_TOKEN_URL: str
+    WAF_RATE_LIMIT_RULE_GROUP_ARN: str
+
     def __init__(self):
         self.env = Env()
         self.cfenv = AppEnv()
@@ -83,6 +144,50 @@ class Config:
             "Managed-AllViewer",
             "Managed-AllViewerAndCloudFrontHeaders-2022-06",
         ]
+
+        self.ACME_DIRECTORY = "NONE"
+        self.ALB_IAM_SERVER_CERTIFICATE_PREFIX = "NONE"
+        self.ALB_WAF_CLOUDWATCH_LOG_GROUP_ARN = "None"
+        self.ALB_LISTENER_ARNS = []
+        self.AWS_COMMERCIAL_ACCESS_KEY_ID = "NONE"
+        self.AWS_COMMERCIAL_GLOBAL_REGION = "NONE"
+        self.AWS_COMMERCIAL_REGION = "NONE"
+        self.AWS_COMMERCIAL_SECRET_ACCESS_KEY = "NONE"
+        self.AWS_GOVCLOUD_ACCESS_KEY_ID = "NONE"
+        self.AWS_GOVCLOUD_REGION = "NONE"
+        self.AWS_GOVCLOUD_SECRET_ACCESS_KEY = "NONE"
+        self.BROKER_PASSWORD = "NONE"
+        self.BROKER_USERNAME = "NONE"
+        self.CDN_LOG_BUCKET = "NONE"
+        self.CDN_WAF_CLOUDWATCH_LOG_GROUP_ARN = "NONE"
+        self.CF_API_URL = "NONE"
+        self.CLOUDFRONT_IAM_SERVER_CERTIFICATE_PREFIX = "NONE"
+        self.DATABASE_ENCRYPTION_KEY = "NONE"
+        self.DEDICATED_ALB_LISTENER_ARN_MAP = {}
+        self.DELETE_WEB_ACL_WAIT_RETRY_TIME = 0
+        self.DEFAULT_CLOUDFRONT_ORIGIN = "NONE"
+        self.DNS_ROOT_DOMAIN = "NONE"
+        self.DNS_VERIFICATION_SERVER = "8.8.8.8:53"
+        self.REDIS_HOST = "NONE"
+        self.REDIS_PASSWORD = "NONE"
+        self.REDIS_PORT = 1234
+        self.REDIS_SSL = False
+        self.ROUTE53_ZONE_ID = "NONE"
+        self.SECRET_KEY = "NONE"
+        self.SMTP_HOST = "NONE"
+        self.SMTP_FROM = "NONE"
+        self.SMTP_CERT = "NONE"
+        self.SMTP_USER = "NONE"
+        self.SMTP_PASS = "NONE"
+        self.SMTP_PORT = 1234
+        self.SMTP_TO = "NONE"
+        self.SMTP_TLS = True
+        self.SQLALCHEMY_DATABASE_URI = "NONE"
+        self.WAF_RATE_LIMIT_RULE_GROUP_ARN = "NONE"
+        self.UAA_BASE_URL = "NONE"
+        self.UAA_CLIENT_ID = "NONE"
+        self.UAA_CLIENT_SECRET = "NONE"
+        self.UAA_TOKEN_URL = "NONE"
 
 
 class AppConfig(Config):
@@ -168,20 +273,20 @@ class AppConfig(Config):
 
 class ProductionConfig(AppConfig):
     def __init__(self):
-        self.ACME_DIRECTORY = "https://acme-v02.api.letsencrypt.org/directory"
         super().__init__()
+        self.ACME_DIRECTORY = "https://acme-v02.api.letsencrypt.org/directory"
 
 
 class StagingConfig(AppConfig):
     def __init__(self):
-        self.ACME_DIRECTORY = "https://acme-v02.api.letsencrypt.org/directory"
         super().__init__()
+        self.ACME_DIRECTORY = "https://acme-v02.api.letsencrypt.org/directory"
 
 
 class DevelopmentConfig(AppConfig):
     def __init__(self):
-        self.ACME_DIRECTORY = "https://acme-staging-v02.api.letsencrypt.org/directory"
         super().__init__()
+        self.ACME_DIRECTORY = "https://acme-staging-v02.api.letsencrypt.org/directory"
 
 
 class UpgradeSchemaConfig(Config):
@@ -277,8 +382,8 @@ class DockerConfig(Config):
         self.SMTP_TO = "doesnt-matter@example.com"
         self.SMTP_FROM = "no-reply@example.com"
         self.SMTP_TLS = False
-        self.SMTP_USER = None
-        self.SMTP_PASS = None
+        self.SMTP_USER = "None"
+        self.SMTP_PASS = "None"
 
         self.WAF_RATE_LIMIT_RULE_GROUP_ARN = "rate-limit-rule-group-fake-arn"
         self.CDN_WAF_CLOUDWATCH_LOG_GROUP_ARN = "fake-waf-cloudwatch-log-grou-arn"

--- a/broker/tasks/waf.py
+++ b/broker/tasks/waf.py
@@ -4,7 +4,6 @@ from sqlalchemy import select, and_
 
 from broker.aws import wafv2_commercial, wafv2_govcloud
 from broker.extensions import config
-from broker.lib.tags import tag_key_exists
 from broker.models import DedicatedALB, ModelTypes, ServiceInstanceTypes
 from broker.tasks.huey import pipeline_operation
 

--- a/pip-tools/requirements.in
+++ b/pip-tools/requirements.in
@@ -14,3 +14,5 @@ psycopg2
 redis
 sqlalchemy-utils
 sap-cf-logging
+types-boto3
+types-boto3[wafv2]

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,8 @@ botocore==1.39.3
     # via
     #   boto3
     #   s3transfer
+botocore-stubs==1.40.27
+    # via types-boto3
 certifi==2025.7.9
     # via requests
 cfenv==0.5.3
@@ -116,11 +118,21 @@ sqlalchemy==2.0.41
     #   sqlalchemy-utils
 sqlalchemy-utils==0.41.2
     # via -r pip-tools/requirements.in
+types-awscrt==0.27.6
+    # via botocore-stubs
+types-boto3[wafv2]==1.40.28
+    # via -r pip-tools/requirements.in
+types-boto3-wafv2==1.40.16
+    # via types-boto3
+types-s3transfer==0.13.1
+    # via types-boto3
 typing-extensions==4.14.1
     # via
     #   alembic
     #   pyopenssl
     #   sqlalchemy
+    #   types-boto3
+    #   types-boto3-wafv2
 urllib3==2.5.0
     # via
     #   botocore

--- a/tests/integration/commands/test_waf.py
+++ b/tests/integration/commands/test_waf.py
@@ -222,7 +222,13 @@ def test_create_dedicated_alb_waf_web_acls_multiple_same_org(
     )
     # Get info about web ACL to set on second dedicated ALB
     wafv2_govcloud.expect_list_web_acls(
-        [dedicated_alb_waf_name],
+        [
+            {
+                "Name": dedicated_alb_waf_name,
+                "Id": dedicated_alb_waf_id,
+                "ARN": dedicated_alb_waf_arn,
+            }
+        ],
         params={
             "Scope": "REGIONAL",
         },
@@ -256,7 +262,13 @@ def test_update_dedicated_alb_web_acl_info(
     wafv2_govcloud,
 ):
     wafv2_govcloud.expect_list_web_acls(
-        [dedicated_alb_waf_name],
+        [
+            {
+                "Name": dedicated_alb_waf_name,
+                "Id": dedicated_alb_waf_id,
+                "ARN": dedicated_alb_waf_arn,
+            }
+        ],
         params={
             "Scope": "REGIONAL",
         },
@@ -282,6 +294,82 @@ def test_update_dedicated_alb_web_acl_info_finds_nothing(
 ):
     wafv2_govcloud.expect_list_web_acls(
         [],
+        params={
+            "Scope": "REGIONAL",
+        },
+    )
+
+    with pytest.raises(RuntimeError):
+        update_dedicated_alb_with_web_acl_info(real_wafv2_govcloud, dedicated_alb)
+
+    wafv2_govcloud.assert_no_pending_responses()
+
+
+def test_update_dedicated_alb_web_acl_info_detects_missing_name(
+    clean_db,
+    dedicated_alb,
+    wafv2_govcloud,
+    dedicated_alb_waf_id,
+    dedicated_alb_waf_arn,
+):
+    wafv2_govcloud.expect_list_web_acls(
+        [
+            {
+                "Id": dedicated_alb_waf_id,
+                "ARN": dedicated_alb_waf_arn,
+            }
+        ],
+        params={
+            "Scope": "REGIONAL",
+        },
+    )
+
+    with pytest.raises(RuntimeError):
+        update_dedicated_alb_with_web_acl_info(real_wafv2_govcloud, dedicated_alb)
+
+    wafv2_govcloud.assert_no_pending_responses()
+
+
+def test_update_dedicated_alb_web_acl_info_detects_missing_id(
+    clean_db,
+    dedicated_alb,
+    wafv2_govcloud,
+    dedicated_alb_waf_name,
+    dedicated_alb_waf_arn,
+):
+    wafv2_govcloud.expect_list_web_acls(
+        [
+            {
+                "Name": dedicated_alb_waf_name,
+                "ARN": dedicated_alb_waf_arn,
+            }
+        ],
+        params={
+            "Scope": "REGIONAL",
+        },
+    )
+
+    with pytest.raises(RuntimeError):
+        update_dedicated_alb_with_web_acl_info(real_wafv2_govcloud, dedicated_alb)
+
+    wafv2_govcloud.assert_no_pending_responses()
+
+
+def test_update_dedicated_alb_web_acl_info_detects_missing_arn(
+    clean_db,
+    dedicated_alb,
+    wafv2_govcloud,
+    dedicated_alb_waf_id,
+    dedicated_alb_waf_name,
+    dedicated_alb_waf_arn,
+):
+    wafv2_govcloud.expect_list_web_acls(
+        [
+            {
+                "Id": dedicated_alb_waf_id,
+                "Name": dedicated_alb_waf_name,
+            }
+        ],
         params={
             "Scope": "REGIONAL",
         },

--- a/tests/integration/commands/test_waf.py
+++ b/tests/integration/commands/test_waf.py
@@ -5,6 +5,7 @@ from broker.commands.waf import (
     wait_for_web_acl_to_exist,
     update_dedicated_alb_waf_web_acls,
     wait_for_associated_waf_web_acl_arn,
+    update_dedicated_alb_web_acl_info,
 )
 from broker.tasks.waf import generate_web_acl_name
 from broker.aws import wafv2_govcloud as real_wafv2_govcloud
@@ -243,6 +244,53 @@ def test_create_dedicated_alb_waf_web_acls_multiple_same_org(
         assert dedicated_alb.dedicated_waf_web_acl_arn == dedicated_alb_waf_arn
         assert dedicated_alb.dedicated_waf_web_acl_id == dedicated_alb_waf_id
         assert dedicated_alb.dedicated_waf_web_acl_name == dedicated_alb_waf_name
+
+
+def test_update_dedicated_alb_web_acl_info(
+    clean_db,
+    dedicated_alb,
+    dedicated_alb_id,
+    dedicated_alb_waf_name,
+    dedicated_alb_waf_id,
+    dedicated_alb_waf_arn,
+    wafv2_govcloud,
+):
+    wafv2_govcloud.expect_list_web_acls(
+        [dedicated_alb_waf_name],
+        params={
+            "Scope": "REGIONAL",
+        },
+    )
+    update_dedicated_alb_web_acl_info(real_wafv2_govcloud, dedicated_alb)
+
+    wafv2_govcloud.assert_no_pending_responses()
+
+    dedicated_alb = clean_db.session.get(
+        DedicatedALB,
+        dedicated_alb_id,
+    )
+
+    assert dedicated_alb.dedicated_waf_web_acl_arn == dedicated_alb_waf_arn
+    assert dedicated_alb.dedicated_waf_web_acl_id == dedicated_alb_waf_id
+    assert dedicated_alb.dedicated_waf_web_acl_name == dedicated_alb_waf_name
+
+
+def test_update_dedicated_alb_web_acl_info_finds_nothing(
+    clean_db,
+    dedicated_alb,
+    wafv2_govcloud,
+):
+    wafv2_govcloud.expect_list_web_acls(
+        [],
+        params={
+            "Scope": "REGIONAL",
+        },
+    )
+
+    with pytest.raises(RuntimeError):
+        update_dedicated_alb_web_acl_info(real_wafv2_govcloud, dedicated_alb)
+
+    wafv2_govcloud.assert_no_pending_responses()
 
 
 def test_associate_dedicated_alb_updates_waf_web_acls(

--- a/tests/integration/commands/test_waf.py
+++ b/tests/integration/commands/test_waf.py
@@ -5,7 +5,7 @@ from broker.commands.waf import (
     wait_for_web_acl_to_exist,
     update_dedicated_alb_waf_web_acls,
     wait_for_associated_waf_web_acl_arn,
-    update_dedicated_alb_web_acl_info,
+    update_dedicated_alb_with_web_acl_info,
 )
 from broker.tasks.waf import generate_web_acl_name
 from broker.aws import wafv2_govcloud as real_wafv2_govcloud
@@ -261,7 +261,7 @@ def test_update_dedicated_alb_web_acl_info(
             "Scope": "REGIONAL",
         },
     )
-    update_dedicated_alb_web_acl_info(real_wafv2_govcloud, dedicated_alb)
+    update_dedicated_alb_with_web_acl_info(real_wafv2_govcloud, dedicated_alb)
 
     wafv2_govcloud.assert_no_pending_responses()
 
@@ -288,7 +288,7 @@ def test_update_dedicated_alb_web_acl_info_finds_nothing(
     )
 
     with pytest.raises(RuntimeError):
-        update_dedicated_alb_web_acl_info(real_wafv2_govcloud, dedicated_alb)
+        update_dedicated_alb_with_web_acl_info(real_wafv2_govcloud, dedicated_alb)
 
     wafv2_govcloud.assert_no_pending_responses()
 

--- a/tests/integration/commands/test_waf.py
+++ b/tests/integration/commands/test_waf.py
@@ -220,10 +220,9 @@ def test_create_dedicated_alb_waf_web_acls_multiple_same_org(
         organization_guid, dedicated_alb.tags
     )
     # Get info about web ACL to set on second dedicated ALB
-    wafv2_govcloud.expect_get_web_acl(
-        dedicated_alb_waf_name,
+    wafv2_govcloud.expect_list_web_acls(
+        [dedicated_alb_waf_name],
         params={
-            "Name": dedicated_alb_waf_name,
             "Scope": "REGIONAL",
         },
     )

--- a/tests/lib/fake_wafv2.py
+++ b/tests/lib/fake_wafv2.py
@@ -243,6 +243,24 @@ class FakeWAFV2(FakeAWS):
 
         self.stubber.add_response(method, {}, request)
 
+    def expect_list_web_acls(self, waf_names: list[str], params: dict):
+        web_acls = []
+        for waf_name in waf_names:
+            web_acls.append(
+                {
+                    "Name": waf_name,
+                    "ARN": generate_fake_waf_web_acl_arn(waf_name),
+                    "Id": generate_fake_waf_web_acl_id(waf_name),
+                }
+            )
+        self.stubber.add_response(
+            "list_web_acls",
+            {
+                "WebACLs": web_acls,
+            },
+            params,
+        )
+
     def expect_get_web_acl(self, waf_name: str, params: dict = {}):
         self.stubber.add_response(
             "get_web_acl",

--- a/tests/lib/fake_wafv2.py
+++ b/tests/lib/fake_wafv2.py
@@ -243,16 +243,7 @@ class FakeWAFV2(FakeAWS):
 
         self.stubber.add_response(method, {}, request)
 
-    def expect_list_web_acls(self, waf_names: list[str], params: dict):
-        web_acls = []
-        for waf_name in waf_names:
-            web_acls.append(
-                {
-                    "Name": waf_name,
-                    "ARN": generate_fake_waf_web_acl_arn(waf_name),
-                    "Id": generate_fake_waf_web_acl_id(waf_name),
-                }
-            )
+    def expect_list_web_acls(self, web_acls: list[dict], params: dict):
         self.stubber.add_response(
             "list_web_acls",
             {

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -258,14 +258,6 @@ def test_config_fixes_db_uri(env, monkeypatch, mocked_env, dburl_in):
 
 @pytest.mark.parametrize("env", env_mappings().keys())
 def test_config_sets_ignore_duplicates_false_by_default(env, monkeypatch, mocked_env):
-
-    config = config_from_env()
-
-    assert not config.IGNORE_DUPLICATE_DOMAINS
-
-
-@pytest.mark.parametrize("env", env_mappings().keys())
-def test_config_sets_ignore_duplicates_false_by_default(env, monkeypatch, mocked_env):
     monkeypatch.setenv("IGNORE_DUPLICATE_DOMAINS", "true")
 
     config = config_from_env()


### PR DESCRIPTION
## Changes proposed in this pull request:

- [update update_dedicated_alb_web_acl_info to use list_web_acls to find already provisioned web ACL](https://github.com/cloud-gov/external-domain-broker/commit/2dcce40f0d8bfd5a502ef7e05e3351df3e464212) 
- [add types-boto3 and types-boto3[wafv2] packages for type hinting](https://github.com/cloud-gov/external-domain-broker/commit/129794239fd88e90ce7a45bbcb6e677ecf597261)
- [improve type hinting of config values](https://github.com/cloud-gov/external-domain-broker/commit/b9c62bf99083a0cde3fb61a5671ba74a01073e59)
- update tests

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing a bug in the `update_dedicated_alb_with_web_acl_info` logic
