### PR TITLE
Fix SMTP config values

### DIFF
--- a/broker/config.py
+++ b/broker/config.py
@@ -181,7 +181,7 @@ class Config:
         self.SMTP_PASS = None
         self.SMTP_PORT = 1234
         self.SMTP_TO = "NONE"
-        self.SMTP_TLS = True
+        self.SMTP_TLS = False
         self.SQLALCHEMY_DATABASE_URI = "NONE"
         self.WAF_RATE_LIMIT_RULE_GROUP_ARN = "NONE"
         self.UAA_BASE_URL = "NONE"


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update default for `SMTP_USER` and `SMTP_PASS` since explicit`None` is required to disable SMTP login: https://github.com/cloud-gov/external-domain-broker/blob/main/broker/smtp.py#L24
- Update default for `SMTP_CERT` to `None` to disable SMTP cert verification by default: https://github.com/cloud-gov/external-domain-broker/blob/main/broker/smtp.py#L19
- Update types for `SMTP_USER`, `SMTP_PASS`, and `SMTP_CERT` to mark them as optional

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None. These config changes affect test environments only and are solely for fixing test failures
