### PR TITLE
Fix update web ACL command logic

### DIFF
--- a/broker/commands/waf.py
+++ b/broker/commands/waf.py
@@ -123,7 +123,7 @@ def update_dedicated_alb_waf_web_acls():
             and associated_web_acl_arn == dedicated_alb.dedicated_waf_web_acl_arn
         ):
             logger.info("Current WAF web ACL already matches expected resource")
-            return
+            continue
 
         # Otherwise, continue and update the associated WAF web ACL. We likely
         # reach this condition because the create_dedicated_alb_waf_web_acls


### PR DESCRIPTION
## Changes proposed in this pull request:

- update update_dedicated_alb_waf_web_acls to skip dedicated ALB if correct WAF is already associated, not return
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing behavior of the update web ACL command logic
