### PR TITLE
replace deprecated code for generating a private key

### DIFF
--- a/broker/tasks/letsencrypt.py
+++ b/broker/tasks/letsencrypt.py
@@ -103,21 +103,22 @@ def generate_private_key(operation_id: int, *, operation, db, **kwargs):
     certificate.subject_alternative_names = service_instance.domain_names
 
     # Create private key.
-    private_key = OpenSSL.crypto.PKey()
-    private_key.generate_key(OpenSSL.crypto.TYPE_RSA, 2048)
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
 
     # Get the PEM
-    private_key_pem_in_binary = OpenSSL.crypto.dump_privatekey(
-        OpenSSL.crypto.FILETYPE_PEM, private_key
+    private_key_bytes = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
     )
 
     # Get the CSR for the domains
     csr_pem_in_binary = crypto_util.make_csr(
-        private_key_pem_in_binary, service_instance.domain_names
+        private_key_bytes, service_instance.domain_names
     )
 
     # Store them as text for later
-    certificate.private_key_pem = private_key_pem_in_binary.decode("utf-8")
+    certificate.private_key_pem = private_key_bytes.decode("utf-8")
     certificate.csr_pem = csr_pem_in_binary.decode("utf-8")
 
     db.session.add(service_instance)


### PR DESCRIPTION
## Changes proposed in this pull request:

- replace deprecated code for generating a private key

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Replacing deprecated code with more well maintained code is good for security
