### PR TITLE
fix run-worker script

### DIFF
--- a/docs/operational.md
+++ b/docs/operational.md
@@ -15,13 +15,13 @@ they're not running. When such pipelines are detected, they're re-enqueued from 
 
 ### Stopping pipelines by hand
 
-Sometimes, a pipeline might be running, and you may want to make it stop. You can do this 
+Sometimes, a pipeline might be running, and you may want to make it stop. You can do this
 by connecting to the database and updating the Operation's `canceled_at` field.
 
 You should [run this update query following the steps outlined below](#safely-running-update-queries):
 
-```
-sql> UPDATE operation SET canceled_at = now() WHERE id = <operation_id>;
+```sql
+UPDATE operation SET canceled_at = now() WHERE id = <operation_id>;
 ```
 
 ### Restarting a pipeline
@@ -29,24 +29,24 @@ sql> UPDATE operation SET canceled_at = now() WHERE id = <operation_id>;
 Sometimes it's useful to restart a pipeline manually, for instance if a pipeline is failing
 on a step, and you know rerunning a previous step is likely to fix it.
 Start by stopping the pipeline as described above. Then wait for the pipeline to attempt to
-rerun the next task (normally ten minutes should be sufficient). 
+rerun the next task (normally ten minutes should be sufficient).
 
 Finally, you will update the record in the `operation` table so the stalled pipeline scanner re-enqueues it.
 
 You should [run this update query following the steps outlined below](#safely-running-update-queries):
 
-```
-sql> UPDATE operation SET canceled_at = null WHERE id = <operation_id>;
+```sql
+UPDATE operation SET canceled_at = null WHERE id = '<operation_id>';
 ```
 
 ### Safely running UPDATE queries
 
 Since it can be very easy to make mistakes with update queries and affect many more rows than
-you intended, we **strongly recommend** querying the database **before updating** to determine 
+you intended, we **strongly recommend** querying the database **before updating** to determine
 how many rows should be affected by your update:
 
-```
-sql> SELECT count(*) FROM operation WHERE id = <operation_id>
+```bash
+sql> SELECT count(*) FROM operation WHERE id = '<operation_id>'
  count
 -------
   1
@@ -55,23 +55,23 @@ sql> SELECT count(*) FROM operation WHERE id = <operation_id>
 
 Then, we also **strongly recommend running your update query in a transaction** like so:
 
-```
+```bash
 sql> BEGIN;
-sql> UPDATE operation SET canceled_at = null WHERE id = <operation_id>;
+sql> UPDATE operation SET canceled_at = null WHERE id = '<operation_id>';
 UPDATE 1
 ```
 
 If the number of rows updated matches your expected number of rows, then you can safely commit
 the transaction and complete the update:
 
-```
-sql> COMMIT;
+```sql
+COMMIT;
 ```
 
 Otherwise, you should rollback the transaction:
 
-```
-sql> ROLLBACK;
+```sql
+ROLLBACK;
 ```
 
 If you have rolled back the transaction, then you should run `SELECT` queries on the database to determine
@@ -81,6 +81,7 @@ then you can retry the update in a transaction.
 ## Updating an instance by hand
 
 Any operation that CAPI might do can be done by:
+
 1. updating the service_instance record
 2. creating an appropriate operation record
 This is because of the scan_for_stalled_pipelines job.
@@ -88,25 +89,26 @@ This is because of the scan_for_stalled_pipelines job.
 *note: this bypasses a lot of validation, so proceed with care.*
 
 Before doing any of the below, you should make sure there are no operations in progress:
-```
-sql> SELECT id FROM operation WHERE
-        service_instance_id = <service_instance_id> AND
-        state = 'in progress' AND
-        canceled_at IS NULL;
+
+```sql
+SELECT id FROM operation WHERE
+service_instance_id = <service_instance_id> AND
+state = 'in progress' AND
+canceled_at IS NULL;
 ```
 
 Example: Someone, for some reason, ran `cf purge-service-instance <service_instance>`,
 but we need to delete the service instance from the broker so the AWS resources get cleaned up.
 All we need to do is create a record in the `operation` table and wait:
 
-```
-sql> INSERT INTO operation (service_instance_id, updated_at, action, state)
-        VALUES (<service_instance_id>, now(), 'Deprovision', 'in progress');
+```sql
+INSERT INTO operation (service_instance_id, updated_at, action, state)
+VALUES (<service_instance_id>, now(), 'Deprovision', 'in progress');
 ```
 
 This could also be used to force an early renewal of a certificate:
 
-```
-sql> INSERT INTO operation (service_instance_id, updated_at, action, state)
-        VALUES (<service_instance_id>, now(), 'Renew', 'in progress');
+```sql
+INSERT INTO operation (service_instance_id, updated_at, action, state)
+VALUES (<service_instance_id>, now(), 'Renew', 'in progress');
 ```

--- a/scripts/run-worker
+++ b/scripts/run-worker
@@ -3,13 +3,17 @@
 set -euo pipefail
 shopt -s inherit_errexit
 
-export PYTHONPATH=$(dirname "$0")/..
-
-opts=""
-
-if [[ ! ${CF_INSTANCE_INDEX:-0} = 0 ]]; then
-    opts="$opts --no-periodic"
-fi
+PYTHONPATH="$(dirname "$0")/..:$PYTHONPATH"
+export PYTHONPATH
 
 # send logs to dev null, since we create other log handlers elsewhere
-exec huey_consumer.py "$@" $opts broker.huey_consumer.huey -l /dev/null
+# see https://huey.readthedocs.io/en/latest/consumer.html#options-for-the-consumer
+huey_consumer_args=(-l /dev/null)
+if [[ ! ${CF_INSTANCE_INDEX:-0} = 0 ]]; then
+    huey_consumer_args+=("--no-periodic")
+fi
+huey_consumer_args+=("$@")
+
+# huey_consumer is an executable provided by the huey package, not our code
+# see https://huey.readthedocs.io/en/latest/index.html#running-the-consumer
+exec huey_consumer broker.huey_consumer.huey "${huey_consumer_args[@]}"


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix run-worker script to use correct executable for huey_consumer 
- refactor creation of dynamic arguments for huey_consumer

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
